### PR TITLE
Diplomatischer text (Layout und Interaktion)

### DIFF
--- a/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -4,6 +4,6 @@
     <div style="background-color: blue; width: 350px; height: 600px"></div>
   </div>
   <div style="display: inline-block; vertical-align: top">
-    <rae-diplomatischer-text [page]="p"></rae-diplomatischer-text>
+    <rae-diplomatischer-text [page]="p" [(gewaehlteSchicht)]="gewaehlteSchicht"></rae-diplomatischer-text>
   </div>
 </div>

--- a/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -1,6 +1,7 @@
 <div *ngFor="let p of pages">
   <h5>{{p}}</h5>
   <div style="display: inline-block; vertical-align: top">
+    <!-- TODO: insert picture component here -->
     <div style="background-color: blue; width: 350px; height: 600px"></div>
   </div>
   <div style="display: inline-block; vertical-align: top">

--- a/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -1,0 +1,9 @@
+<div *ngFor="let p of pages">
+  <h5>{{p}}</h5>
+  <div style="display: inline-block; vertical-align: top">
+    <div style="background-color: blue; width: 350px; height: 600px"></div>
+  </div>
+  <div style="display: inline-block; vertical-align: top">
+    <rae-diplomatischer-text [page]="p"></rae-diplomatischer-text>
+  </div>
+</div>

--- a/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -10,6 +10,7 @@ import { Component, Input } from '@angular/core';
 })
 export class FassungDiplomatischComponent {
 
-  @Input() pages;
+  @Input() pages: any;
+  gewaehlteSchicht: string = 'schicht0';
 
 }

--- a/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/konvolute/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -1,0 +1,15 @@
+/**
+ * Created by Reto Baumgartner (rfbaumgartner) on 24.07.17.
+ */
+import { Component, Input } from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'rae-fassung-diplomatisch',
+  templateUrl: 'fassung-diplomatisch.component.html'
+})
+export class FassungDiplomatischComponent {
+
+  @Input() pages;
+
+}

--- a/src/client/app/konvolute/fassung/fassung.component.html
+++ b/src/client/app/konvolute/fassung/fassung.component.html
@@ -70,12 +70,9 @@
                           </md-card-footer>
                         </md-card>
 
-                        <md-card>
+                        <md-card *ngIf="konvolut_type === 'manuskripte' || konvolut_type === 'notizbuecher'">
                           <md-card-content *ngIf="zeigeDiplomatisch">
-
-                            <!-- TODO -->
-                            TODO: Modul für Bild und diplomatische Umschrift einfügen
-
+                            <rae-fassung-diplomatisch [pages]="pages"></rae-fassung-diplomatisch>
                           </md-card-content>
                           <md-card-footer>
                             <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch">

--- a/src/client/app/konvolute/fassung/fassung.component.ts
+++ b/src/client/app/konvolute/fassung/fassung.component.ts
@@ -28,8 +28,10 @@ export class FassungComponent implements OnInit {
     'Wind',
     'Wasser'
   ];
+  // TODO dynamisieren
 
-  poems: Array<any>;
+  pages: Array<any> = ['page1', 'page2'];
+  // TODO dynamisieren
 
   // for testings
   searchQuery: string;
@@ -57,14 +59,6 @@ export class FassungComponent implements OnInit {
 
     let searchParams = new FulltextSearch;
     searchParams.searchstring = 'e';
-
-    // TODO dynamisieren
-
-    this.route.params
-      .switchMap((params: Params) =>
-        this.http.get(searchParams.toString()))
-      .map(response => response.json().subjects)
-      .subscribe((res: Array<any>) => this.poems = res);
 
     this.konvolut_type = this.route.snapshot.url[ 0 ].path;
     this.sub = this.route.params.subscribe(params => {

--- a/src/client/app/konvolute/fassung/fassung.module.ts
+++ b/src/client/app/konvolute/fassung/fassung.module.ts
@@ -16,18 +16,21 @@ import {
 } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { RegisterspalteModule } from '../shared/registerspalte/registerspalte.module';
+import { DiplomatischerTextModule } from '../../shared/diplomatischer-text/diplomatischer-text.module';
 import { FassungRoutingModule } from './fassung-routing.module';
+import { RegisterspalteModule } from '../shared/registerspalte/registerspalte.module';
 
-import { FassungComponent } from './fassung.component';
 import { FassungBlaetternComponent } from './fassung-blaettern/fassung-blaettern.component';
+import { FassungComponent } from './fassung.component';
+import { FassungDiplomatischComponent } from './fassung-diplomatisch/fassung-diplomatisch.component';
 import { FassungSteckbriefComponent } from './fassung-steckbrief/fassung-steckbrief.component';
+import { FassungWeitereComponent } from './fassung-weitere/fassung-weitere.component';
 import { FassungWerkzeugleisteComponent } from './fassung-werkzeugleiste/fassung-werkzeugleiste.component';
-import {FassungWeitereComponent} from "./fassung-weitere/fassung-weitere.component";
 
 @NgModule({
   imports: [
     BrowserModule,
+    DiplomatischerTextModule,
     FassungRoutingModule,
     FormsModule,
     HttpModule,
@@ -43,6 +46,7 @@ import {FassungWeitereComponent} from "./fassung-weitere/fassung-weitere.compone
   declarations: [
     FassungBlaetternComponent,
     FassungComponent,
+    FassungDiplomatischComponent,
     FassungSteckbriefComponent,
     FassungWeitereComponent,
     FassungWerkzeugleisteComponent

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
@@ -3,7 +3,15 @@ md-button-toggle-group {
 }
 
 md-button-toggle {
-  width: 50%;
+  width: 25%;
   height: 36px;
   font-size: 80%;
+}
+
+.rae-diplomatic-movable {
+  cursor: move;
+}
+
+.rae-diplomatic-in-place {
+  cursor: auto;
 }

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
@@ -1,0 +1,9 @@
+md-button-toggle-group {
+  width: 80%;
+}
+
+md-button-toggle {
+  width: 50%;
+  height: 36px;
+  font-size: 80%;
+}

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -1,21 +1,34 @@
 <div>
   <md-toolbar>
-    <md-button-toggle-group [(ngModel)]="defaultView">
-      <md-button-toggle [ngStyle]="{'color': farbeNeutral}"
-                        title="Anfangsschicht ohne Auszeichnung"
-                        (click)="zeigeSchicht0()" value="schicht0">0</md-button-toggle>
-      <md-button-toggle [ngStyle]="{'color': farbeErste}"
-                        title="Grundschicht (kleiner Verbund), nur ausnahmsweise ausgezeichnet"
-                        (click)="zeigeSchicht1()" value="schicht1">1</md-button-toggle>
-      <md-button-toggle [ngStyle]="{'color': farbeEinfuegung}"
-                        title="Texteinfügung entgegen dem linearen Verlauf der Niederschrift"
-                        (click)="zeigeSchicht2()" value="schicht2">2</md-button-toggle>
-      <md-button-toggle [ngStyle]="{'color': farbeLetzte}"
-                        title="Endschicht (Basis für edierten Text"
-                        (click)="zeigeSchicht3()" value="schicht3">3</md-button-toggle>
+    <md-button-toggle-group [(ngModel)]="gewaehlteSchicht" name="schichtwaehler{{page}}"
+                            (ngModelChange)="gewaehlteSchichtChange.emit(gewaehlteSchicht)">
+      <md-button-toggle value="schicht0"
+                        [ngStyle]="{'color': farbeNeutral}"
+                        title="Anfangsschicht ohne Auszeichnung">
+        0
+      </md-button-toggle>
+      <md-button-toggle value="schicht1"
+                        [ngStyle]="{'color': farbeErste}"
+                        title="Grundschicht (kleiner Verbund), nur ausnahmsweise ausgezeichnet">
+        1
+      </md-button-toggle>
+      <md-button-toggle value="schicht2"
+                        [ngStyle]="{'color': farbeEinfuegung}"
+                        title="Texteinfügung entgegen dem linearen Verlauf der Niederschrift">
+        2
+      </md-button-toggle>
+      <md-button-toggle value="schicht3"
+                        [ngStyle]="{'color': farbeLetzte}"
+                        title="Endschicht (Basis für edierten Text)">
+        3
+      </md-button-toggle>
     </md-button-toggle-group>
-    <md-button-toggle [(ngModel)]="textIsMovable"
-                      title="Umschrift verschiebbar machen">↔</md-button-toggle>
+    <md-checkbox [(ngModel)]="textIsMovable"
+                        title="Umschrift verschiebbar machen">↔</md-checkbox> <!-- as checkbox because button toggle is broken -->
+
   </md-toolbar>
-  <div class="umschrift edtext edtext_hs" [innerHtml]="text"></div>
+  <div class="umschrift edtext edtext_hs"
+       [innerHtml]="text"
+       [ngClass]="{'rae-diplomatic-movable': textIsMovable, 'rae-diplomatic-in-place': !textIsMovable}"></div>
+  <p *ngIf="textIsMovable">movable</p><p *ngIf="!textIsMovable">in place</p><p>{{gewaehlteSchicht}}</p>
 </div>

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -1,0 +1,21 @@
+<div>
+  <md-toolbar>
+    <md-button-toggle-group [(ngModel)]="defaultView">
+      <md-button-toggle [ngStyle]="{'color': farbeNeutral}"
+                        title="Anfangsschicht ohne Auszeichnung"
+                        (click)="zeigeSchicht0()" value="schicht0">0</md-button-toggle>
+      <md-button-toggle [ngStyle]="{'color': farbeErste}"
+                        title="Grundschicht (kleiner Verbund), nur ausnahmsweise ausgezeichnet"
+                        (click)="zeigeSchicht1()" value="schicht1">1</md-button-toggle>
+      <md-button-toggle [ngStyle]="{'color': farbeEinfuegung}"
+                        title="Texteinfügung entgegen dem linearen Verlauf der Niederschrift"
+                        (click)="zeigeSchicht2()" value="schicht2">2</md-button-toggle>
+      <md-button-toggle [ngStyle]="{'color': farbeLetzte}"
+                        title="Endschicht (Basis für edierten Text"
+                        (click)="zeigeSchicht3()" value="schicht3">3</md-button-toggle>
+    </md-button-toggle-group>
+    <md-button-toggle [(ngModel)]="textIsMovable"
+                      title="Umschrift verschiebbar machen">↔</md-button-toggle>
+  </md-toolbar>
+  <div class="umschrift edtext edtext_hs" [innerHtml]="text"></div>
+</div>

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -23,12 +23,13 @@
         3
       </md-button-toggle>
     </md-button-toggle-group>
+
+    <!-- TODO replace with better layout. Now as checkbox because button toggle is broken -->
     <md-checkbox [(ngModel)]="textIsMovable"
-                        title="Umschrift verschiebbar machen">↔</md-checkbox> <!-- as checkbox because button toggle is broken -->
+                        title="Umschrift verschiebbar machen">↔</md-checkbox>
 
   </md-toolbar>
   <div class="umschrift edtext edtext_hs"
        [innerHtml]="text"
        [ngClass]="{'rae-diplomatic-movable': textIsMovable, 'rae-diplomatic-in-place': !textIsMovable}"></div>
-  <p *ngIf="textIsMovable">movable</p><p *ngIf="!textIsMovable">in place</p><p>{{gewaehlteSchicht}}</p>
 </div>

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
@@ -1,0 +1,183 @@
+/**
+ * Created by Reto Baumgartner (rfbaumgartner) on 05.07.17.
+ */
+
+import { AfterViewInit, Component, Input, OnChanges, OnInit } from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'rae-diplomatischer-text',
+  templateUrl: 'diplomatischer-text.component.html',
+  styleUrls: [ 'diplomatischer-text.component.css' ]
+})
+export class DimplomatischerTextComponent implements OnInit, AfterViewInit, OnChanges {
+
+  @Input() page;
+
+  farbeNeutral = '#6e6e6e';
+  farbeMarkierung = '#d00501';
+  farbeEinfuegung = '#007FFF';
+  farbeZeilennummer = '#FF0000';
+  farbeLetzte = '#F00000';
+  farbeErste = '#800000';
+
+  defaultView = 'schicht0';
+  textIsMovable: boolean = false;
+  // TODO: herausfinden wie das geht
+
+  text: string = '<div class="transkription"><p>Baum</p><p><span class="einfuegung">Durch die Zweige </span><span class="einfuegung_gestr">schaut es</span><br /><span class="streichung grundschicht">Durch die Zweige</span> 				</p> 				<span class="weiss">schauten die Augen</span><span class="einfuegung_gestr">hervor</span><br /> 				<span class="streichung"><span class="grundschicht">schau<span class="ueberschrieben">en</span></span><span class="einfuegung_gestr ersetzung">t </span><span class="grundschicht">die Augen <span class="ueberschrieben">hervor</span></span> </span><span class="ersetzung streichung einfuegung_gestr">voller</span><span class="grundschicht">,</span><br /><span class="weiss">schauten die</span><span class="streichung einfuegung">Trauer hervor.</span> 				<p class="grundschicht"> 					<span class="streichung">voller Trauer,</span> 				</p> 				<p> 					<span class="einfuegung">schaut es hervor und senkt</span><br /><span class="streichung grundschicht">aber das Licht</span> 				</p> 				<span class="streichung grundschicht">auf den Blättern</span>&nbsp;<span class="einfuegung_gestr">schwarz und tr</span><br /><span class="weiss">auf den Blät&nbsp; tern </span><span class="einfuegung">langsam die Lider,</span> 				<p> 					<span class="streichung grundschicht">ist wie ein Lächeln.</span><span class="einfuegung"> schwarz,&nbsp;voller&nbsp;Trauer</span> 				</p> 				<p> 					<span class="streichung">Durch die Zweige schaut es,&nbsp;</span><span class="einfuegung_gestr">die Wimpern<br /></span><span class="weiss">Durch die Zweige schaut es,&nbsp;</span><span class="einfuegung_gestr">hervor</span> 				</p> 				<p> 					<span class="streichung">die Wimp </span> 				</p> 				<p> 					<span class="streichung">[langsam senkend hervor </span> 				</p> 				<p> 					<span class="streichung">schwarz hervor und senkt</span> 				</p> 				<p> 					<span class="streichung">langsam die]</span> 				</p> 				<p> 					<span class="streichung">hervor und senkt</span>&nbsp;<span class="streichung">schaut es </span> 				</p> 				<p> 					<span class="streichung grundschicht">schwarz hervor und senkt</span> 				</p> 				<p> 					<span class="streichung grundschicht">langsam die Wimpern.</span><br /><span class="weiss">langsam voller Trauer die</span><span class="einfuegung_gestr">Lider</span>.<br /><span class="weiss">langsam</span><span class="streichung">voller Trauer die Wimpern</span>. // 				</p> 			</div>';
+// TODO: dynamisieren
+
+  ngOnInit() {
+    this.zeigeSchicht0();
+  }
+  ngOnChanges() {
+    this.zeigeSchicht0();
+  }
+  ngAfterViewInit() {
+    this.zeigeSchicht0();
+  }
+
+  zeigeSchicht0() {
+    // faerbe alles in der Grundfarbe ein ausser Zeilennummern und Markierungen
+
+    for (let entry of document.getElementsByClassName('transkription')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('zeile')) { entry.style.color = this.farbeZeilennummer; }
+    for (let entry of document.getElementsByClassName('markierung')) { entry.style.color = this.farbeMarkierung; }
+    for (let entry of document.getElementsByClassName('herausgeber')) { entry.style.color = this.farbeMarkierung; }
+
+    for (let entry of document.getElementsByClassName('streichung_typo')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+  }
+
+  zeigeSchicht1() {
+    // faerbe alles in der Grundfarbe ein ausser die Grundschicht
+
+    for (let entry of document.getElementsByClassName('transkription')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('grundschicht')) {
+      entry.setAttribute('style', 'font-weight:normal');
+      entry.style.color = this.farbeErste;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.setAttribute('style', 'font-weight:normal');
+        child.style.color = this.farbeErste;
+      }
+    }
+  }
+
+  zeigeSchicht2() {
+    // faerbe alle Einfuegungen blau ein
+
+    for (let entry of document.getElementsByClassName('transkription')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('einfuegung')) {
+      entry.style.color = this.farbeEinfuegung;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeEinfuegung;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('einfuegung_typo')) {
+      entry.style.color = this.farbeEinfuegung;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeEinfuegung;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('einfuegung_gestr_typo')) {
+      entry.style.color = this.farbeEinfuegung;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeEinfuegung;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('streichung_typo')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('einfuegung_gestr')) {
+      entry.style.color = this.farbeEinfuegung;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeEinfuegung;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('markierung')) { entry.style.color = this.farbeMarkierung; }
+    for (let entry of document.getElementsByClassName('zeile')) { entry.style.color = this.farbeZeilennummer; }
+
+  }
+
+  zeigeSchicht3() {
+    // faerbe alles, das nicht gestrichen wurde, in der Farbe der Enfassung ein
+
+    for (let entry of document.getElementsByClassName('transkription')) {
+      entry.style.color = this.farbeLetzte;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeLetzte;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('einfuegung_gestr')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('einfuegung_gestr_typo')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('unsicher_gestr')) { entry.style.color = this.farbeNeutral; }
+
+    for (let entry of document.getElementsByClassName('streichung')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('streichung_typo')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+
+    for (let entry of document.getElementsByClassName('ueberschrieben')) { entry.style.color = this.farbeNeutral; }
+    for (let entry of document.getElementsByClassName('streichung_doppel')) { entry.style.color = this.farbeNeutral; }
+
+    for (let entry of document.getElementsByClassName('blocktilgung')) {
+      entry.style.color = this.farbeNeutral;
+      for (let child of entry.getElementsByTagName('*')) {
+        child.style.color = this.farbeNeutral;
+      }
+    }
+  }
+}

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
@@ -2,7 +2,7 @@
  * Created by Reto Baumgartner (rfbaumgartner) on 05.07.17.
  */
 
-import { AfterViewInit, Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, DoCheck, EventEmitter, Input, OnInit, Output } from '@angular/core';
 
 @Component({
   moduleId: module.id,
@@ -10,9 +10,12 @@ import { AfterViewInit, Component, Input, OnChanges, OnInit } from '@angular/cor
   templateUrl: 'diplomatischer-text.component.html',
   styleUrls: [ 'diplomatischer-text.component.css' ]
 })
-export class DimplomatischerTextComponent implements OnInit, AfterViewInit, OnChanges {
+export class DimplomatischerTextComponent implements OnInit, DoCheck {
 
-  @Input() page;
+  @Input() page: any;
+  @Input() gewaehlteSchicht: string;
+  @Output() gewaehlteSchichtChange: EventEmitter<string> = new EventEmitter<string>();
+
 
   farbeNeutral = '#6e6e6e';
   farbeMarkierung = '#d00501';
@@ -21,7 +24,6 @@ export class DimplomatischerTextComponent implements OnInit, AfterViewInit, OnCh
   farbeLetzte = '#F00000';
   farbeErste = '#800000';
 
-  defaultView = 'schicht0';
   textIsMovable: boolean = false;
   // TODO: herausfinden wie das geht
 
@@ -29,13 +31,31 @@ export class DimplomatischerTextComponent implements OnInit, AfterViewInit, OnCh
 // TODO: dynamisieren
 
   ngOnInit() {
-    this.zeigeSchicht0();
+    this.updateSchichten();
   }
-  ngOnChanges() {
-    this.zeigeSchicht0();
+
+  ngDoCheck() {
+    this.updateSchichten();
   }
-  ngAfterViewInit() {
-    this.zeigeSchicht0();
+
+  updateSchichten() {
+    switch (this.gewaehlteSchicht) {
+      case 'schicht0':
+        this.zeigeSchicht0();
+        break;
+      case 'schicht1':
+        this.zeigeSchicht1();
+        break;
+      case 'schicht2':
+        this.zeigeSchicht2();
+        break;
+      case 'schicht3':
+        this.zeigeSchicht3();
+        break;
+      default:
+        this.zeigeSchicht0();
+        break;
+    }
   }
 
   zeigeSchicht0() {

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.module.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.module.ts
@@ -1,0 +1,41 @@
+/**
+ * Created by Reto Baumgartner (rfbaumgartner) on 24.07.17.
+ */
+
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HttpModule } from '@angular/http';
+import {
+  MdButtonModule,
+  MdButtonToggleModule,
+  MdCardModule,
+  MdGridListModule,
+  MdIconModule,
+  MdInputModule,
+  MdListModule, MdToolbarModule
+} from '@angular/material';
+import { BrowserModule } from '@angular/platform-browser';
+import { DimplomatischerTextComponent } from './diplomatischer-text.component';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    FormsModule,
+    HttpModule,
+    MdButtonModule,
+    MdButtonToggleModule,
+    MdCardModule,
+    MdGridListModule,
+    MdIconModule,
+    MdInputModule,
+    MdListModule,
+    MdToolbarModule
+  ],
+  declarations: [
+    DimplomatischerTextComponent
+  ],
+  exports: [ DimplomatischerTextComponent ],
+  providers: []
+})
+export class DiplomatischerTextModule {
+}

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.module.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.module.ts
@@ -3,18 +3,15 @@
  */
 
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import {
   MdButtonModule,
-  MdButtonToggleModule,
-  MdCardModule,
-  MdGridListModule,
-  MdIconModule,
-  MdInputModule,
-  MdListModule, MdToolbarModule
+  MdButtonToggleModule, MdCheckboxModule,
+  MdToolbarModule
 } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
+
 import { DimplomatischerTextComponent } from './diplomatischer-text.component';
 
 @NgModule({
@@ -24,12 +21,9 @@ import { DimplomatischerTextComponent } from './diplomatischer-text.component';
     HttpModule,
     MdButtonModule,
     MdButtonToggleModule,
-    MdCardModule,
-    MdGridListModule,
-    MdIconModule,
-    MdInputModule,
-    MdListModule,
-    MdToolbarModule
+    MdCheckboxModule,
+    MdToolbarModule,
+    ReactiveFormsModule
   ],
   declarations: [
     DimplomatischerTextComponent


### PR DESCRIPTION
Bei Notizbüchern und Manuskripten kann nun die diplomatische Transkription angezeigt werden.

### To review

z.B. auf einer Seite wie http://localhost:5555/manuskripte/manuskripte-1979/I_am_label_100, klick auf "Diplomatischen Text anzeigen". Das Original ist auf http://kunoraeber.ch/lyrik/index.php/notizbuecher/notizbuch-1979/item/221-baum?start=1 
 
* Die Transkription erscheint einfarbig grau
* In der Transkription sind Streichungen, Kursivstellungen und Fettschrift sichtbar.
* Zeilennummern sind rot hervorgehoben
* Klicken auf die Buttons mit den Zahlen verändert die Farben im Text (wie bei der Originalseite). Bei mehrseitigen Gedichten verändern sich die Farben auf allen Seiten gemeinsam. Die Buttons stimmen in der Auswahl auch überein.
* Der Slide-Button hat noch keine Funktionalität (der Text sollte verschiebbar werden). Die Buttons auf den verschiedenen Seiten sollen aber unabhängig getogglet werden.

Entspricht den User-Stories NIE-48 und -49. Vor allem bei Story 48 folgt der Pull-Request der bestehenden Seite und nimmt keine neuen Funktionalitäten auf, wie sie in der Story stehen.