### PR TITLE
Einfache Suche in Navigationsleiste

### DIFF
--- a/src/client/app/core/core.module.ts
+++ b/src/client/app/core/core.module.ts
@@ -17,6 +17,7 @@ import { RegisterModule } from '../register/register.module';
 import { StatischModule } from '../statisch/statisch.module';
 import { SucheModule } from '../suche/suche.module';
 import { SynopseModule } from '../synopse/synopse.module';
+import { MdInputModule } from '@angular/material';
 
 @NgModule({
   imports: [
@@ -28,6 +29,7 @@ import { SynopseModule } from '../synopse/synopse.module';
     RegisterModule,
     SucheModule,
     SynopseModule,
+    MdInputModule,
     RouterModule.forRoot([
       { path: '', redirectTo: '/start', pathMatch: 'full' },
       { path: '**', component: PageNotFoundComponent }

--- a/src/client/app/core/kopfzeile.component.html
+++ b/src/client/app/core/kopfzeile.component.html
@@ -8,6 +8,7 @@
     </div>
     <div class="rt-grid-7 rt-omega">
       <rae-navigationsleiste></rae-navigationsleiste>
+      <rae-basic-search></rae-basic-search>
     </div>
     <div class="clear"></div>
   </div>

--- a/src/client/app/suche/basic-search/basic-search.component.css
+++ b/src/client/app/suche/basic-search/basic-search.component.css
@@ -11,3 +11,7 @@
   padding-right: 5px;
   caret-color: #d8d8d8;
 }
+
+.basic-search:focus {
+  outline: none;
+}

--- a/src/client/app/suche/basic-search/basic-search.component.css
+++ b/src/client/app/suche/basic-search/basic-search.component.css
@@ -2,16 +2,28 @@
   border-top: 0;
   border-left: 0;
   border-right: 0;
-  border-bottom: 1px solid #d8d8d8;
+  border-bottom: 1px solid #ddd;
   background-color: transparent;
-  font-size: 12px;
-  color: #d8d8d8;
+  font-size: 13px;
+  color: #ddd;
   width: 150px;
   padding-left: 5px;
   padding-right: 5px;
-  caret-color: #d8d8d8;
+  caret-color: #ddd;
+  opacity: 0.8;
+}
+
+.search-button {
+  opacity: 0.7;
 }
 
 .basic-search:focus {
   outline: none;
+}
+
+.search-region:hover .basic-search,
+.basic-search:focus,
+.search-region:hover .search-button,
+.basic-search:focus + .search-button {
+  opacity: 1;
 }

--- a/src/client/app/suche/basic-search/basic-search.component.css
+++ b/src/client/app/suche/basic-search/basic-search.component.css
@@ -1,0 +1,13 @@
+.basic-search {
+  border-top: 0;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 1px solid #d8d8d8;
+  background-color: transparent;
+  font-size: 12px;
+  color: #d8d8d8;
+  width: 150px;
+  padding-left: 5px;
+  padding-right: 5px;
+  caret-color: #d8d8d8;
+}

--- a/src/client/app/suche/basic-search/basic-search.component.html
+++ b/src/client/app/suche/basic-search/basic-search.component.html
@@ -1,9 +1,8 @@
-<input class="basic-search" #searchfield [value]="searchfieldText" [hidden]="hideSearchfield"
-       [placeholder]="placeholder" (focus)="placeholder=''" (keyup.enter)="sendRequest(basicsearch.value)"
-       [(ngModel)]="searchfieldText"
-       name="basicsearch"
-       #basicsearch="ngModel">
-<button md-icon-button [type]="hideSearchfield ? 'reset' : 'submit'"
-        (click)="hideSearchfield ? hideSearchfield = false : sendRequest(basicsearch.value)">
+<span class="search-region">
+<input class="basic-search" #searchfield [hidden]="hideSearchfield"
+       [placeholder]="placeholder" (focus)="placeholder=''" (keyup.enter)="sendRequest(searchfield.value)">
+<button md-icon-button class="search-button" [type]="hideSearchfield ? 'reset' : 'submit'"
+        (click)="hideSearchfield ? hideSearchfield = false : sendRequest(searchfield.value)">
   <md-icon>search</md-icon>
 </button>
+</span>

--- a/src/client/app/suche/basic-search/basic-search.component.html
+++ b/src/client/app/suche/basic-search/basic-search.component.html
@@ -1,7 +1,11 @@
-<form class="example-form" [hidden]="showSearchfield">
-  <input class="basic-search" #searchfield
-         [value]="searchfieldText">
+<form class="example-form" #form="ngForm" (ngSubmit)="sendRequest(basicsearch.value)" novalidate>
+  <input class="basic-search" #searchfield [value]="searchfieldText" [hidden]="hideSearchfield"
+         (focus)="searchfieldText = ''" (keyup.enter)="sendRequest(basicsearch.value)" [(ngModel)]="searchfieldText"
+         name="basicsearch"
+         #basicsearch="ngModel">
+  <button md-icon-button [type]="hideSearchfield ? 'reset' : 'submit'"
+          (click)="hideSearchfield ? hideSearchfield = false : sendRequest(basicsearch.value)">
+    <md-icon>search</md-icon>
+  </button>
 </form>
-<button md-icon-button (click)="showSearchfield = !showSearchfield">
-  <md-icon>search</md-icon>
-</button>
+

--- a/src/client/app/suche/basic-search/basic-search.component.html
+++ b/src/client/app/suche/basic-search/basic-search.component.html
@@ -1,5 +1,7 @@
-<form class="example-form">
-  <md-input-container>
-    <input mdInput placeholder="Suche">
-  </md-input-container>
+<form class="example-form" [hidden]="showSearchfield">
+  <input class="basic-search" #searchfield
+         [value]="searchfieldText">
 </form>
+<button md-icon-button (click)="showSearchfield = !showSearchfield">
+  <md-icon>search</md-icon>
+</button>

--- a/src/client/app/suche/basic-search/basic-search.component.html
+++ b/src/client/app/suche/basic-search/basic-search.component.html
@@ -1,11 +1,9 @@
-<form class="example-form" #form="ngForm" (ngSubmit)="sendRequest(basicsearch.value)" novalidate>
-  <input class="basic-search" #searchfield [value]="searchfieldText" [hidden]="hideSearchfield"
-         (focus)="searchfieldText = ''" (keyup.enter)="sendRequest(basicsearch.value)" [(ngModel)]="searchfieldText"
-         name="basicsearch"
-         #basicsearch="ngModel">
-  <button md-icon-button [type]="hideSearchfield ? 'reset' : 'submit'"
-          (click)="hideSearchfield ? hideSearchfield = false : sendRequest(basicsearch.value)">
-    <md-icon>search</md-icon>
-  </button>
-</form>
-
+<input class="basic-search" #searchfield [value]="searchfieldText" [hidden]="hideSearchfield"
+       [placeholder]="placeholder" (focus)="placeholder=''" (keyup.enter)="sendRequest(basicsearch.value)"
+       [(ngModel)]="searchfieldText"
+       name="basicsearch"
+       #basicsearch="ngModel">
+<button md-icon-button [type]="hideSearchfield ? 'reset' : 'submit'"
+        (click)="hideSearchfield ? hideSearchfield = false : sendRequest(basicsearch.value)">
+  <md-icon>search</md-icon>
+</button>

--- a/src/client/app/suche/basic-search/basic-search.component.html
+++ b/src/client/app/suche/basic-search/basic-search.component.html
@@ -1,0 +1,5 @@
+<form class="example-form">
+  <md-input-container>
+    <input mdInput placeholder="Suche">
+  </md-input-container>
+</form>

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -17,7 +17,7 @@ export class BasicSearchComponent {
 
   sendRequest(values: any) {
     console.log(values);
-    this.router.navigateByUrl('/suche',);
+    this.router.navigateByUrl('/suche/' + encodeURIComponent(values),);
   }
 
 

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'rae-basic-search',
+  templateUrl: './basic-search.component.html'
+})
+export class BasicSearchComponent {
+
+}

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -3,8 +3,11 @@ import { Component } from '@angular/core';
 @Component({
   moduleId: module.id,
   selector: 'rae-basic-search',
-  templateUrl: './basic-search.component.html'
+  templateUrl: './basic-search.component.html',
+  styleUrls: ['./basic-search.component.css']
 })
 export class BasicSearchComponent {
+  showSearchfield: boolean = true;
+  searchfieldText: string = 'Suche...';
 
 }

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -16,7 +16,6 @@ export class BasicSearchComponent {
   }
 
   sendRequest(values: any) {
-    console.log(values);
     this.router.navigateByUrl('/suche/' + encodeURIComponent(values),);
   }
 

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 export class BasicSearchComponent {
 
   hideSearchfield: boolean = true;
-  searchfieldText: string = 'Suche...';
+  placeholder = 'Suche...';
 
   constructor(private router: Router) {
   }

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -7,7 +7,13 @@ import { Component } from '@angular/core';
   styleUrls: ['./basic-search.component.css']
 })
 export class BasicSearchComponent {
-  showSearchfield: boolean = true;
+
+  hideSearchfield: boolean = true;
   searchfieldText: string = 'Suche...';
+
+  sendRequest(values: any) {
+    console.log(values);
+  }
+
 
 }

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   moduleId: module.id,
@@ -11,8 +12,12 @@ export class BasicSearchComponent {
   hideSearchfield: boolean = true;
   searchfieldText: string = 'Suche...';
 
+  constructor(private router: Router) {
+  }
+
   sendRequest(values: any) {
     console.log(values);
+    this.router.navigateByUrl('/suche',);
   }
 
 

--- a/src/client/app/suche/basic-search/basic-search.component.ts
+++ b/src/client/app/suche/basic-search/basic-search.component.ts
@@ -13,6 +13,10 @@ export class BasicSearchComponent {
   placeholder = 'Suche...';
 
   constructor(private router: Router) {
+    router.events.subscribe(changes => {
+      this.hideSearchfield = true;
+      this.placeholder = 'Suche...';
+    });
   }
 
   sendRequest(values: any) {

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -3,7 +3,7 @@ import { Http, Response } from '@angular/http';
 import { globalSearchVariableService } from './globalSearchVariablesService';
 import { AbstractControl } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import {Location} from '@angular/common';
+import { Location } from '@angular/common';
 
 
 @Component({
@@ -85,6 +85,9 @@ export class SucheComponent implements OnInit {
   input: Array<any>;
   searchTerm: string;
 
+  constructor(private http: Http, private route: ActivatedRoute, private location: Location) {
+    this.route.params.subscribe(params => console.log(params));
+  }
 
   handleSearchEvent(arg: AbstractControl) {
     console.log(arg);
@@ -93,14 +96,10 @@ export class SucheComponent implements OnInit {
     this.location.replaceState('/suche/' + this.inputSearchStringToBeParsed);
   }
 
-  constructor(private http: Http, private route: ActivatedRoute, private location: Location) {
-    this.route.params.subscribe( params => console.log(params) );
-  }
-
   ngOnInit() {
     //console.log(this.vocabulary);
     this.initialQuery(this.vocabulary, this.resourceTypesPath);
-    if ( !this.inputSearchStringToBeParsed ){
+    if (!this.inputSearchStringToBeParsed) {
       this.inputSearchStringToBeParsed = this.route.snapshot.params['queryParameters'];
       console.log('Queryparameters: ' + this.inputSearchStringToBeParsed);
     }
@@ -278,7 +277,7 @@ export class SucheComponent implements OnInit {
           + ' in: ' + queries[this.i][this.j].where);
       }
     }
-    console.log( 'Query Object:')
+    console.log('Query Object:');
     console.log(queries);
   }
 

--- a/src/client/app/suche/suche.module.ts
+++ b/src/client/app/suche/suche.module.ts
@@ -30,6 +30,7 @@ import { TextgridModule } from './textgrid/textgrid.module';
 import { SearchForOneResourceModule } from './searchForOneResourceComponent/searchForOneResource.module';
 import { ParserModule } from './parser/parser.module';
 import { SuchmaskeComponent } from './suchmaske/suchmaske.component';
+import { BasicSearchComponent } from './basic-search/basic-search.component';
 
 @NgModule({
   imports: [
@@ -61,9 +62,13 @@ import { SuchmaskeComponent } from './suchmaske/suchmaske.component';
   ],
   declarations: [
     SucheComponent,
-    SuchmaskeComponent
+    SuchmaskeComponent,
+    BasicSearchComponent
   ],
-  exports: [ SucheComponent ],
+  exports: [
+    SucheComponent,
+    BasicSearchComponent
+  ],
   providers: []
 })
 export class SucheModule {

--- a/src/client/app/suche/textgrid/textgrid.component.html
+++ b/src/client/app/suche/textgrid/textgrid.component.html
@@ -5,13 +5,14 @@
     <md-card [ngClass]="{'rae-poem-card-grid': showGrid, 'rae-poem-card-cols': showCols}">
       <md-card-subtitle *ngIf="p.date">{{p.date}}</md-card-subtitle>
       <md-card-title>
-        <a class="item" [routerLink]="[p.value[0]]" routerLinkActive="active" [innerHTML]="highlight(p.value[0],searchTerm)">
+        <a class="item" [routerLink]="[p.value[0]]" routerLinkActive="active"
+           [innerHTML]="highlight(p.value[0],searchTerm)">
 
         </a>
       </md-card-title>
 
 
-      <md-card-content [ngClass]="{'rae-poem-card-content-grid': showGrid, 'rae-poem-card-content-cols': showCols}" >
+      <md-card-content [ngClass]="{'rae-poem-card-content-grid': showGrid, 'rae-poem-card-content-cols': showCols}">
         <div class="rae-poem" [innerHTML]="highlight(p.value[0],searchTerm)"></div>
       </md-card-content>
 
@@ -21,7 +22,7 @@
         <div class="catItemTagsBlock">
           <span>Metadata:</span>
           <ul class="catItemTags">
-            <li *ngFor="let s of p.valuelabel; let j = index" >
+            <li *ngFor="let s of p.valuelabel; let j = index">
               <a class="item" [routerLink]="['/synopsen/' + s]" routerLinkActive="active">
                 {{s}}
               </a>

--- a/src/client/app/suche/textgrid/textgrid.component.ts
+++ b/src/client/app/suche/textgrid/textgrid.component.ts
@@ -53,7 +53,7 @@ export class TextgridComponent implements OnChanges {
   }
 
   highlight(textToHighlight: string, searchTerm: string) {
-    if(searchTerm === undefined) {
+    if (searchTerm === undefined) {
       return textToHighlight;
     }
     return textToHighlight.replace(new RegExp(searchTerm, 'gi'), match => {

--- a/src/client/app/suche/textgrid/textgrid.module.ts
+++ b/src/client/app/suche/textgrid/textgrid.module.ts
@@ -4,15 +4,17 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MdButtonToggleModule,
-  MdCardModule,
-  MdInputModule,
+import {
   MdButtonModule,
+  MdButtonToggleModule,
+  MdCardModule,
+  MdCheckboxModule,
   MdGridListModule,
   MdIconModule,
+  MdInputModule,
   MdMenuModule,
-  MdCheckboxModule,
-  MdSelectModule} from '@angular/material';
+  MdSelectModule
+} from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -28,22 +28,6 @@
 
 <rae-app>Loading...</rae-app>
 
-<script defer>
-  (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r;
-    i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date();
-    a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0];
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m)
-  })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-  ga('create', '<%= GOOGLE_ANALYTICS_ID %>', 'auto');
-  ga('send', 'pageview');
-</script>
-
 <script>
   // Fixes undefined module function in SystemJS bundle
   function module() {


### PR DESCRIPTION
Die einfache Suche in der Navigationsleiste erlaubt es, Suchbegriffe über den Suchschlitz abzusetzen. Es wird dann die erweiterte Suche mit gewünschten Suchresultaten aufgerufen.

Zu testen: Eine Suche sollte auf die Suchseite weiterleiten und den Suchbegriff enkodiert in der URL enthalten.