### PR TITLE
change links to convolutes in konv-steckbrief to the pattern /type/ko…

### DIFF
--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-publikation.component.html
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-publikation.component.html
@@ -1,7 +1,7 @@
 <span *ngFor="let pub of publications; let i = index">
   <span>
     <span>
-      <a [routerLink]="['/' + pub['title']]">{{ pub['title'] }}</a>
+      <a [routerLink]="['/drucke/' + pub['alias']]">{{ pub['title'] }}</a>
       ({{ pub['size'] }} Gedichte)</span><span *ngIf="i+1 < publications.length">,</span>
   </span>
 </span>

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-publikation.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-publikation.component.ts
@@ -24,15 +24,17 @@ export class KonvolutSteckbriefPublikationComponent implements OnChanges {
     this.publications = [];
 
     for (let i = 0; i < this.konvolutIRI.length; i++) {
-      this.publications.push({'title': '', 'size': ''});
+      this.publications.push({'title': '', 'size': '', 'alias': ''});
 
       try {
         this.sub = this.http.get('http://knora.nie-ine.ch/v1/resources/' + encodeURIComponent(this.konvolutIRI[i]))
           .map(response => response.json()).subscribe(res => {
             this.publications[i]['title'] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ].utf8str;
+            this.publications[i]['alias'] = res.props['http://www.knora.org/ontology/text#hasAlias'].values[0].utf8str;
           });
       } catch (TypeError) {
         this.publications[i]['title'] = null;
+        this.publications[i]['alias'] = null;
       }
 
       try {

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-stufen.component.html
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-stufen.component.html
@@ -1,3 +1,3 @@
-<span *ngFor="let k of konvolutTitel; let i = index">
-  <a [routerLink]="['/' + k]">{{k}}</a><span *ngIf="i+1 < konvolutTitel.length">,</span>
+<span *ngFor="let pub of publications; let i = index">
+  <a [routerLink]="['/' + konvolutTypeMap[pub['type']] + '/' + pub['alias']]">{{pub['title']}}</a><span *ngIf="i+1 < publications.length">,</span>
 </span>

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-stufen.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-stufen.component.ts
@@ -14,24 +14,41 @@ export class KonvolutSteckbriefStufenComponent implements OnChanges {
 
   @Input() konvolutIRI: Array<string>;
 
-  konvolutTitel: Array<string>;
+  publications: Array<any>;
+  konvolutTypeMap = {
+    'poem notebook': 'notizbuecher',
+    'poem manuscript convolute': 'manuskripte',
+    'poem typescript convolute': 'typoskripte',
+    'poem typescript convolute with image': 'typoskripte',
+    'printed poem book publication': 'drucke',
+    'poly-author publication convolute': 'drucke',
+    'poem postcard convolute': 'manuskripte',
+    'diary convolute': 'material',
+    'letter convolute': 'material'
+  };
   private sub: any;
 
   constructor(private http: Http) {}
 
   ngOnChanges() {
-    this.konvolutTitel = [];
+    this.publications = [];
 
     for (let i = 0; i < this.konvolutIRI.length; i++) {
-      this.sub = this.http.get('http://knora.nie-ine.ch/v1/resources/' + encodeURIComponent(this.konvolutIRI[i]))
-        .map(response => response.json()).subscribe(res => {
+      this.publications.push({'title': '', 'type': '', 'alias': ''});
 
-          try {
-            this.konvolutTitel.push(res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ].utf8str);
-          } catch (TypeError) {
-            // skip convolute
-          }
-        });
+      try {
+        this.sub = this.http.get('http://knora.nie-ine.ch/v1/resources/' + encodeURIComponent(this.konvolutIRI[i]))
+          .map(response => response.json()).subscribe(res => {
+            this.publications[i]['title'] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ].utf8str;
+            this.publications[i]['alias'] = res.props['http://www.knora.org/ontology/text#hasAlias'].values[0].utf8str;
+            this.publications[i]['type'] = res.resinfo.restype_label;
+
+          });
+      } catch (TypeError) {
+        this.publications[i]['title'] = null;
+        this.publications[i]['alias'] = null;
+        this.publications[i]['type'] = null;
+      }
     }
   }
 }


### PR DESCRIPTION
…nvolute-id

Die Links im Steckbrief (Publikation, Vorstufen, Stufen, spätere Stufen) bauen auf dem Schema /konvoluttyp/konvolutId auf (Schema aus ca. Juli).

Verschiedene Konvolute aufrufen und schauen, ob die Links entsprechend zusammengebaut sind.