### PR TITLE
replace hardcoded API adress with variable in Konvolut-Steckbrief

### DIFF
--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-datierung.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-datierung.component.ts
@@ -4,6 +4,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { Http } from '@angular/http';
 import { DateFormatService } from '../../shared/utilities/date-format.service';
+import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
 
 
 @Component({
@@ -25,7 +26,8 @@ export class KonvolutSteckbriefDatierungComponent implements OnChanges {
   ngOnChanges() {
 
     if (this.dateIRI) {
-      this.sub = this.http.get('http://knora.nie-ine.ch/v1/resources/' + encodeURIComponent(this.dateIRI))
+      this.sub = this.http.get(globalSearchVariableService.API_URL
+        + '/resources/' + encodeURIComponent(this.dateIRI))
         .map(response => response.json()).subscribe(res => {
 
           try {

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-publikation.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-publikation.component.ts
@@ -5,6 +5,7 @@ import { Component, Input, OnChanges } from '@angular/core';
 import { Http } from '@angular/http';
 import { ExtendedSearch, KnoraProperty } from '../../shared/utilities/knora-api-params';
 import { ActivatedRoute, Params } from '@angular/router';
+import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
 
 
 @Component({
@@ -27,7 +28,8 @@ export class KonvolutSteckbriefPublikationComponent implements OnChanges {
       this.publications.push({'title': '', 'size': '', 'alias': ''});
 
       try {
-        this.sub = this.http.get('http://knora.nie-ine.ch/v1/resources/' + encodeURIComponent(this.konvolutIRI[i]))
+        this.sub = this.http.get(globalSearchVariableService.API_URL
+          + '/resources/' + encodeURIComponent(this.konvolutIRI[i]))
           .map(response => response.json()).subscribe(res => {
             this.publications[i]['title'] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ].utf8str;
             this.publications[i]['alias'] = res.props['http://www.knora.org/ontology/text#hasAlias'].values[0].utf8str;

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-stufen.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-stufen.component.ts
@@ -3,6 +3,7 @@
  */
 import { Component, Input, OnChanges } from '@angular/core';
 import { Http } from '@angular/http';
+import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
 
 
 @Component({
@@ -37,7 +38,8 @@ export class KonvolutSteckbriefStufenComponent implements OnChanges {
       this.publications.push({'title': '', 'type': '', 'alias': ''});
 
       try {
-        this.sub = this.http.get('http://knora.nie-ine.ch/v1/resources/' + encodeURIComponent(this.konvolutIRI[i]))
+        this.sub = this.http.get(globalSearchVariableService.API_URL
+          + '/resources/' + encodeURIComponent(this.konvolutIRI[i]))
           .map(response => response.json()).subscribe(res => {
             this.publications[i]['title'] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ].utf8str;
             this.publications[i]['alias'] = res.props['http://www.knora.org/ontology/text#hasAlias'].values[0].utf8str;

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.ts
@@ -4,6 +4,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { Http } from '@angular/http';
 import { DateFormatService } from '../../shared/utilities/date-format.service';
+import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
 
 
 @Component({
@@ -44,7 +45,8 @@ export class KonvolutSteckbriefComponent implements OnChanges {
 
   ngOnChanges() {
     if (this.IRI) {
-      this.sub = this.http.get('http://knora.nie-ine.ch/v1/resources/' + encodeURIComponent(this.IRI))
+      this.sub = this.http.get(globalSearchVariableService.API_URL
+        + '/resources/' + encodeURIComponent(this.IRI))
         .map(response => response.json()).subscribe(res => {
 
           this.konvoluttyp = res.resinfo.restype_label;


### PR DESCRIPTION
Bisher waren die Requests auf die Basler Knora hartcodiert. Jetzt verwenden die Komponenten die globale Variable.

Beim Testen müssen weiterhin Steckbriefe angezeigt werden und wenn vorhanden sollten auch Datierung, Publikation und Stufen im Steckbrief stehen (Stichproben machen).