### PR TITLE
Reintegred "suche" for the text-grid title.

### DIFF
--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -13,7 +13,7 @@
            [routerLink]="produceFassungsLink(p[0],p[3])" routerLinkActive="active"
            [innerHTML]="highlight(p[0],searchTermArray)">
         </a>
-        <a class="item" *ngIf="contentType == 'synopse'"
+        <a class="item" *ngIf="contentType == 'synopse' || contentType == 'suche' "
           [routerLink]="'/' + p[7] + produceFassungsLink(p[0],p[3])" routerLinkActive="active"
            [innerHTML]="highlight(p[0],searchTermArray)">
         </a>


### PR DESCRIPTION
Just a small fix to reintegrate the search view in the text-grid title.