### PR TITLE
Nie-127 Fassung: Zeige richtige Seiten

### DIFF
--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch-seiten.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch-seiten.component.ts
@@ -16,27 +16,23 @@ export class FassungDiplomatischSeitenComponent implements OnChanges {
 
   @Output() propertiesReset = new EventEmitter();
 
-  properties = { 'diplIRI': '', 'pagenumber': '', 'picData': '' };
+  properties = { 'pageIRI': '', 'pagenumber': '', 'picData': '' };
 
   private sub: any;
 
-  constructor(private http: Http){
+  constructor(private http: Http) {
   }
 
   ngOnChanges() {
-
     if (this.pageIRI) {
       this.sub = this.http.get(globalSearchVariableService.API_URL + '/resources/' + encodeURIComponent(this.pageIRI))
         .map(results => results.json())
-        .subscribe(res =>{
-          this.properties['pagenumber'] = res.props[ 'http://www.knora.org/ontology/work#hasPageNumber' ].values[ 0 ].utf8str;
-          for (let j = 0; j < res.incoming.length; j++) {
-            if (res.incoming[ j ].ext_res_id.pid === 'http://www.knora.org/ontology/text#isDiplomaticTranscriptionOfTextOnPage') {
-              this.properties['diplIRI'] = res.incoming[ j ].ext_res_id.id;
-            }
-          }
+        .subscribe(res => {
+          this.properties[ 'pagenumber' ] = res.props[ 'http://www.knora.org/ontology/work#hasPageNumber' ].values[ 0 ].utf8str;
           this.properties[ 'picData' ] = res.resinfo.locdata;
+          this.properties[ 'pageIRI' ] = this.pageIRI;
           this.propertiesReset.emit(this.properties);
+          console.log(res.props);
         });
     }
   }

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch-seiten.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch-seiten.component.ts
@@ -32,7 +32,6 @@ export class FassungDiplomatischSeitenComponent implements OnChanges {
           this.properties[ 'picData' ] = res.resinfo.locdata;
           this.properties[ 'pageIRI' ] = this.pageIRI;
           this.propertiesReset.emit(this.properties);
-          console.log(res.props);
         });
     }
   }

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -1,19 +1,24 @@
-<ng-container *ngFor="let pageIRI of pageIRIs">
-  <rae-fassung-diplomatisch-seiten [pageIRI]="pageIRI" (propertiesReset)="addPage($event)"></rae-fassung-diplomatisch-seiten>
+<!--
+<ng-container *ngFor="let diplIRI of diplomaticIRIs">
+  <rae-fassung-diplomatisch-seiten [diplomaticIRI]="diplIRI" (propertiesReset)="addPage($event)"></rae-fassung-diplomatisch-seiten>
 </ng-container>
+-->
 
 <div #diplomatischKarte>
-<div *ngFor="let p of pages">
-  <h5>{{p['pagenumber']}}</h5>
-  <div style="display: inline-block; vertical-align: top">
-    <rae-image-frame
-      [pictureData]="p['picData']"
-      [initWidth]="cardWidth"
-      (pictureIncreased)="pictureIncreased.emit(null)"
-      (pictureReduced)="pictureReduced.emit(null)"></rae-image-frame>
+  <div *ngFor="let p of pages">
+    <h5>{{p['pagenumber']}}</h5>
+    <div *ngIf="p['picData']" style="display: inline-block; vertical-align: top">
+      <rae-image-frame
+        [pictureData]="p['picData']"
+        [initWidth]="cardWidth"
+        (pictureIncreased)="pictureIncreased.emit(null)"
+        (pictureReduced)="pictureReduced.emit(null)"></rae-image-frame>
+    </div>
+    <div style="display: inline-block; vertical-align: top">
+      <rae-diplomatischer-text [textIRI]="p['diplIRI']" [(gewaehlteSchicht)]="gewaehlteSchicht"></rae-diplomatischer-text>
+    </div>
+    <rae-fassung-diplomatisch-seiten [pageIRI]="p['pageIRI']"
+                                     (propertiesReset)="addPage($event)">
+    </rae-fassung-diplomatisch-seiten>
   </div>
-  <div style="display: inline-block; vertical-align: top">
-    <rae-diplomatischer-text [textIRI]="p['diplIRI']" [(gewaehlteSchicht)]="gewaehlteSchicht"></rae-diplomatischer-text>
-  </div>
-</div>
 </div>

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -2,6 +2,8 @@
  * Created by Reto Baumgartner (rfbaumgartner) on 24.07.17.
  */
 import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
+import { Http } from '@angular/http';
+import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
 
 @Component({
   moduleId: module.id,
@@ -10,7 +12,7 @@ import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnChanges, O
 })
 export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
 
-  @Input() pageIRIs: any;
+  @Input() diplomaticIRIs: any;
 
   @Output() pictureReduced = new EventEmitter();
   @Output() pictureIncreased = new EventEmitter();
@@ -21,8 +23,36 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
 
   private sub: any;
 
+  constructor(private http: Http) {};
+
   ngOnChanges() {
     this.pages = [];
+
+    if (this.diplomaticIRIs) {
+      for (let i = 0; i < this.diplomaticIRIs.length; i++) {
+        let page = {
+          'diplIRI': this.diplomaticIRIs[i],
+          'pageIRI': '',
+          'pagenumber': '',
+          'picData': ''
+        };
+
+        this.sub = this.http.get(globalSearchVariableService.API_URL + /resources/
+          + encodeURIComponent(this.diplomaticIRIs[i]))
+          .map(results => results.json())
+          .subscribe(res => {
+            try {
+              page['pageIRI'] = res.props['http://www.knora.org/ontology/text#isDiplomaticTranscriptionOfTextOnPage'].values[0];
+              console.log(page['pageIRI']);
+            } catch (TypeError) {
+              page[ 'pageIRI' ] = '';
+            }
+          });
+
+        this.pages.push(page);
+      }
+
+    }
   }
 
   @ViewChild('diplomatischKarte')
@@ -36,12 +66,16 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
     }
   }
 
-  addPage(values: Array<string>) {
-    this.pages.push(values);
-    this.sortPages();
-    console.log(this.pages);
+  addPage(values: any) {
+    for (let i = 0; i < this.pages.length; i++) {
+      if (values['pageIRI'] = this.pages[i]['pageIRI']) {
+        this.pages[i]['pagenumber'] = values['pagenumber'];
+        this.pages[i]['picData'] = values['picData'];
+      }
+    }
   }
 
+  // TODO kann nicht sortieren, wenn alle Seiten alle Nummern haben.
   sortPages() {
     this.pages = this.pages.sort((n1, n2) => {
       const k1 = n1.value[ 'pagenumber' ];

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -58,7 +58,7 @@
 
                       <md-card *ngIf="konvolutType === 'PoemManuscriptConvolute' || konvolutType === 'PoemNotebook'">
                         <md-card-content *ngIf="zeigeDiplomatisch">
-                          <rae-fassung-diplomatisch [pageIRIs]="pageIRIs"
+                          <rae-fassung-diplomatisch [diplomaticIRIs]="diplomaticIRIs"
                                                     (pictureReduced)="show_register = true;"
                                                     (pictureIncreased)="show_register = false;">
                           </rae-fassung-diplomatisch>

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -27,6 +27,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   urlPrefix: string = 'http://rdfh.ch/kuno-raeber/';
 
   pageIRIs: Array<string>;
+  diplomaticIRIs: Array<string>;
 
   poem_id: string;
   poemTitle: string;
@@ -79,6 +80,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         this.textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];
         this.getEditedPoemText(this.textEdition);
         this.pageIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isOnPage' ].values;
+        this.diplomaticIRIs = res.props['http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription'].values;
         this.poemSeqnum = res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ];
         this.poemConvoluteType = res.resdata[ 'restype_name' ].split('#')[ 1 ];
         switch (this.poemConvoluteType) {


### PR DESCRIPTION
The diplomatic transcription shows now the correct text peaces and their pictures (as soon as they're in the DB). 

The order of the pages has still to be done.

For checking: look at some poems in notebooks or manuscripts and toggle the diplomatic transcription view. The snippets should correspond to the edited text and make up the whole poem.