### PR TITLE
NIE-85 Diplomatische Umschrift verschiebbar machen

### DIFF
--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -15,7 +15,10 @@
         (pictureReduced)="pictureReduced.emit(null)"></rae-image-frame>
     </div>
     <div style="display: inline-block; vertical-align: top">
-      <rae-diplomatischer-text [textIRI]="p['diplIRI']" [(gewaehlteSchicht)]="gewaehlteSchicht"></rae-diplomatischer-text>
+      <rae-diplomatischer-text [textIRI]="p['diplIRI']"
+                               [(gewaehlteSchicht)]="gewaehlteSchicht"
+                               [(textIsMovable)]="textIsMovable">
+      </rae-diplomatischer-text>
     </div>
     <rae-fassung-diplomatisch-seiten [pageIRI]="p['pageIRI']"
                                      (propertiesReset)="addPage($event)">

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -20,6 +20,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
   cardWidth: number;
   pages: Array<any> = [];
   gewaehlteSchicht: string = 'schicht0';
+  textIsMovable: boolean = false;
 
   private sub: any;
 

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -56,6 +56,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
     }
 
     this.gewaehlteSchicht = 'schicht0';
+    this.textIsMovable = false;
   }
 
   @ViewChild('diplomatischKarte')

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -54,6 +54,8 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
       }
 
     }
+
+    this.gewaehlteSchicht = 'schicht0';
   }
 
   @ViewChild('diplomatischKarte')

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
@@ -2,16 +2,8 @@ md-button-toggle-group {
   width: 80%;
 }
 
-md-button-toggle {
+md-button-toggle, button {
   width: 25%;
   height: 36px;
   font-size: 80%;
-}
-
-.rae-diplomatic-movable {
-  cursor: move;
-}
-
-.rae-diplomatic-in-place {
-  cursor: auto;
 }

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -31,8 +31,7 @@
     </button>
 
   </md-toolbar>
-  <div class="umschrift edtext edtext_hs"
-       [ngClass]="{'rae-diplomatic-movable': textIsMovable, 'rae-diplomatic-in-place': !textIsMovable}">
+  <div class="umschrift edtext edtext_hs">
     <div class="transkription" [innerHtml]="text"></div>
   </div>
 </div>

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="rae-diplomatic">
   <md-toolbar>
     <md-button-toggle-group [(ngModel)]="gewaehlteSchicht" name="schichtwaehler{{textIRI}}"
                             (ngModelChange)="gewaehlteSchichtChange.emit(gewaehlteSchicht)">
@@ -24,9 +24,11 @@
       </md-button-toggle>
     </md-button-toggle-group>
 
-    <!-- TODO replace with better layout. Now as checkbox because button toggle is broken -->
-    <md-checkbox [(ngModel)]="textIsMovable"
-                        title="Umschrift verschiebbar machen">↔</md-checkbox>
+    <button md-raised-button (click)="toggleDraggable()" title="Umschrift verschiebbar machen">
+      <md-icon *ngIf="textIsMovable">check_box</md-icon>
+      <md-icon *ngIf="!textIsMovable">check_box_outline_blank</md-icon>
+      ↔
+    </button>
 
   </md-toolbar>
   <div class="umschrift edtext edtext_hs"

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
@@ -5,6 +5,7 @@
 import { Component, DoCheck, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { Http } from '@angular/http';
 import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
+declare var $ :any;
 
 @Component({
   moduleId: module.id,
@@ -16,8 +17,10 @@ export class DimplomatischerTextComponent implements OnInit, DoCheck, OnChanges 
 
   @Input() gewaehlteSchicht: string;
   @Input() textIRI: string;
-  @Output() gewaehlteSchichtChange: EventEmitter<string> = new EventEmitter<string>();
+  @Input() textIsMovable: boolean;
 
+  @Output() gewaehlteSchichtChange: EventEmitter<string> = new EventEmitter<string>();
+  @Output() textIsMovableChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   farbeNeutral = '#6e6e6e';
   farbeMarkierung = '#d00501';
@@ -25,9 +28,6 @@ export class DimplomatischerTextComponent implements OnInit, DoCheck, OnChanges 
   farbeZeilennummer = '#FF0000';
   farbeLetzte = '#F00000';
   farbeErste = '#800000';
-
-  textIsMovable: boolean = false;
-  // TODO: herausfinden wie das geht
 
   text: string;
 
@@ -60,7 +60,7 @@ export class DimplomatischerTextComponent implements OnInit, DoCheck, OnChanges 
     if(this.textIRI) {
       this.sub = this.http.get(globalSearchVariableService.API_URL + '/resources/' + encodeURIComponent(this.textIRI))
         .map(response => response.json())
-        .subscribe(res =>{
+        .subscribe(res => {
           this.text = res.props[ 'http://www.knora.org/ontology/text#hasContent' ].values[ 0 ].utf8str;
           this.updateSchichten();
         });
@@ -284,4 +284,22 @@ export class DimplomatischerTextComponent implements OnInit, DoCheck, OnChanges 
       }
     }
   }
+
+  toggleDraggable() {
+    this.textIsMovable = !this.textIsMovable;
+    this.textIsMovableChange.emit(this.textIsMovable);
+
+    if (this.textIsMovable) {
+      $('.rae-diplomatic').draggable({disabled: false, cursor: 'move'});
+    } else {
+      $('.rae-diplomatic').draggable({disabled: true, cursor: 'auto'});
+    }
+    /*$('.umschrift').toggle(function() {
+        jQuery(".umschrift").draggable({disabled:false,cursor:"move"}).css( {cursor:"move"});
+      },
+      function() {
+        jQuery(".umschrift").draggable({disabled: true}).css( {cursor:"auto"});
+      });*/
+  }
+
 }

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.module.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.module.ts
@@ -7,7 +7,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import {
   MdButtonModule,
-  MdButtonToggleModule, MdCheckboxModule,
+  MdButtonToggleModule, MdCheckboxModule, MdIconModule,
   MdToolbarModule
 } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
@@ -22,6 +22,7 @@ import { DimplomatischerTextComponent } from './diplomatischer-text.component';
     MdButtonModule,
     MdButtonToggleModule,
     MdCheckboxModule,
+    MdIconModule,
     MdToolbarModule,
     ReactiveFormsModule
   ],

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -25,6 +25,8 @@
   class="logo-type-custom headerstyle-dark font-family-helvetica font-size-is-default menu-type-dropdownmenu layout-mode-responsive col12">
 
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
 
 <rae-app>Loading...</rae-app>
 


### PR DESCRIPTION
Die diplomatische Umschrift ist jetzt verschiebbar mit Hilfe von jQuery (nach Absprache mit Sascha).

Zum Testen: 
- Zu einer Fassung navigieren, warten bis alle Daten geladen sind (vor allem in der Registerspalte)
- Text anklicken und ziehen (Text sollte ausgewählt werden mit dem Cursor)
- Button `<->` klicken
- Text anklicken und ziehen (Text sollte sich verschieben
- Damit ein bisschen spielen

PS: der Branch hat irrtümlicherweise die Nummer NIE-82