### PR TITLE
NIE-127: Fassung: Diplomatische Transkription: Sortierung

### DIFF
--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch-seiten.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch-seiten.component.ts
@@ -16,7 +16,7 @@ export class FassungDiplomatischSeitenComponent implements OnChanges {
 
   @Output() propertiesReset = new EventEmitter();
 
-  properties = { 'pageIRI': '', 'pagenumber': '', 'picData': '' };
+  properties = { 'pageIRI': '', 'pagenumber': '', 'picData': '', 'origName': '' };
 
   private sub: any;
 
@@ -31,6 +31,8 @@ export class FassungDiplomatischSeitenComponent implements OnChanges {
           this.properties[ 'pagenumber' ] = res.props[ 'http://www.knora.org/ontology/work#hasPageNumber' ].values[ 0 ].utf8str;
           this.properties[ 'picData' ] = res.resinfo.locdata;
           this.properties[ 'pageIRI' ] = this.pageIRI;
+          this.properties[ 'origName' ]
+            = res.resinfo.locdata.origname.split('/')[ res.resinfo.locdata.origname.split('/').length - 1 ];
           this.propertiesReset.emit(this.properties);
         });
     }

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -1,7 +1,7 @@
 <div #diplomatischKarte>
   <div *ngFor="let p of pages">
-    <h5>{{p['pagenumber']}}</h5>
     <div style="display: inline-block; vertical-align: top">
+      <h4><span>{{ p['pagenumber'] }}</span> <span>({{ p['origName'] }})</span> </h4>
       <rae-image-frame *ngIf="p['picData']"
         [pictureData]="p['picData']"
         [initWidth]="cardWidth"

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -1,20 +1,14 @@
-<!--
-<ng-container *ngFor="let diplIRI of diplomaticIRIs">
-  <rae-fassung-diplomatisch-seiten [diplomaticIRI]="diplIRI" (propertiesReset)="addPage($event)"></rae-fassung-diplomatisch-seiten>
-</ng-container>
--->
-
 <div #diplomatischKarte>
   <div *ngFor="let p of pages">
     <h5>{{p['pagenumber']}}</h5>
-    <div *ngIf="p['picData']" style="display: inline-block; vertical-align: top">
-      <rae-image-frame
+    <div style="display: inline-block; vertical-align: top">
+      <rae-image-frame *ngIf="p['picData']"
         [pictureData]="p['picData']"
         [initWidth]="cardWidth"
         (pictureIncreased)="pictureIncreased.emit(null)"
         (pictureReduced)="pictureReduced.emit(null)"></rae-image-frame>
     </div>
-    <div style="display: inline-block; vertical-align: top">
+    <div *ngIf="p['diplIRI']" style="display: inline-block; vertical-align: top">
       <rae-diplomatischer-text [textIRI]="p['diplIRI']"
                                [(gewaehlteSchicht)]="gewaehlteSchicht"
                                [(textIsMovable)]="textIsMovable">

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -35,7 +35,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
     if (this.diplomaticIRIs) {
       for (let i = 0; i < this.diplomaticIRIs.length; i++) {
         let seqnum: number;
-        this.pages.push({'diplIRI': null, 'pageIRI': null, 'pagenumber': null, 'picData': null});
+        this.pages.push({'diplIRI': null, 'pageIRI': null, 'pagenumber': null, 'picData': null, 'origName': null});
 
         this.sub = this.http.get(globalSearchVariableService.API_URL + /resources/
           + encodeURIComponent(this.diplomaticIRIs[i]))
@@ -81,6 +81,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
       if (values['pageIRI'] === this.pages[i]['pageIRI']) {
         this.pages[i]['pagenumber'] = values['pagenumber'];
         this.pages[i]['picData'] = values['picData'];
+        this.pages[i]['origName'] = values['origName'];
       }
     }
   }

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -37,7 +37,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
         let seqnum: number;
         this.pages.push({'diplIRI': null, 'pageIRI': null, 'pagenumber': null, 'picData': null, 'origName': null});
 
-        this.sub = this.http.get(globalSearchVariableService.API_URL + /resources/
+        this.sub = this.http.get(globalSearchVariableService.API_URL + '/resources/'
           + encodeURIComponent(this.diplomaticIRIs[i]))
           .map(results => results.json())
           .subscribe(res => {

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -17,6 +17,9 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
   @Output() pictureReduced = new EventEmitter();
   @Output() pictureIncreased = new EventEmitter();
 
+  @ViewChild('diplomatischKarte')
+  diplomatischKarte: ElementRef;
+
   cardWidth: number;
   pages: Array<any> = [];
   gewaehlteSchicht: string = 'schicht0';
@@ -31,36 +34,39 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
 
     if (this.diplomaticIRIs) {
       for (let i = 0; i < this.diplomaticIRIs.length; i++) {
-        let page = {
-          'diplIRI': this.diplomaticIRIs[i],
-          'pageIRI': '',
-          'pagenumber': '',
-          'picData': ''
-        };
+        let seqnum: number;
+        this.pages.push({'diplIRI': null, 'pageIRI': null, 'pagenumber': null, 'picData': null});
 
         this.sub = this.http.get(globalSearchVariableService.API_URL + /resources/
           + encodeURIComponent(this.diplomaticIRIs[i]))
           .map(results => results.json())
           .subscribe(res => {
             try {
-              page['pageIRI'] = res.props['http://www.knora.org/ontology/text#isDiplomaticTranscriptionOfTextOnPage'].values[0];
-              console.log(page['pageIRI']);
+              seqnum = Number(res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ]);
             } catch (TypeError) {
-              page[ 'pageIRI' ] = '';
+              console.log('Cannot get seqnum for this page.');
+              seqnum = 100;
+            }
+
+            try {
+              this.pages[seqnum][ 'pageIRI' ]
+                = res.props[ 'http://www.knora.org/ontology/text#isDiplomaticTranscriptionOfTextOnPage' ].values[ 0 ];
+            } catch (TypeError) {
+              console.log('Cannot set IRI of page for this page.');
+            }
+
+            try {
+              this.pages[seqnum]['diplIRI'] = this.diplomaticIRIs[i];
+            } catch (TypeError) {
+              console.log('Cannot set IRI of diplomatic transcription for this page.');
             }
           });
-
-        this.pages.push(page);
       }
 
     }
-
     this.gewaehlteSchicht = 'schicht0';
     this.textIsMovable = false;
   }
-
-  @ViewChild('diplomatischKarte')
-  diplomatischKarte: ElementRef;
 
   ngAfterViewInit() {
     if (this.diplomatischKarte.nativeElement.offsetWidth > 300) {
@@ -72,27 +78,10 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
 
   addPage(values: any) {
     for (let i = 0; i < this.pages.length; i++) {
-      if (values['pageIRI'] = this.pages[i]['pageIRI']) {
+      if (values['pageIRI'] === this.pages[i]['pageIRI']) {
         this.pages[i]['pagenumber'] = values['pagenumber'];
         this.pages[i]['picData'] = values['picData'];
       }
     }
-  }
-
-  // TODO kann nicht sortieren, wenn alle Seiten alle Nummern haben.
-  sortPages() {
-    this.pages = this.pages.sort((n1, n2) => {
-      const k1 = n1.value[ 'pagenumber' ];
-      const k2 = n2.value[ 'pagenumber' ];
-      if (k1 > k2) {
-        return 1;
-      }
-
-      if (k1 < k2) {
-        return -1;
-      }
-
-      return 0;
-    });
   }
 }

--- a/src/client/app/shared/image-frame/image-frame.component.html
+++ b/src/client/app/shared/image-frame/image-frame.component.html
@@ -19,8 +19,6 @@ For the kitchen sink
 <div>
   <md-card>
     <md-card-content *ngIf="ausgeklappt">
-      <span>{{ orignameWithoutPath }}</span>
-
       <div [ngStyle]="{'height': height + px, 'width': width + px, 'overflow-y': overflow, 'resize': resize}" #picFrame>
         <!--  <img src="http://test-02.salsah.org/core/sendlocdata.php?res=212767&qtype=full&reduce={{ zoomfactor }}"
                class="rae-image_resizeable"> -->

--- a/src/client/app/shared/image-frame/image-frame.component.ts
+++ b/src/client/app/shared/image-frame/image-frame.component.ts
@@ -37,7 +37,6 @@ export class ImageFrameComponent implements OnInit {
     this.pictureIdBase = this.pictureData.path.split(this.pictureData.nx + ',' + this.pictureData.ny)[ 0 ];
     this.width = this.initWidth;
     this.height = Math.ceil(this.width * this.pictureData.ny / this.pictureData.nx);
-    this.orignameWithoutPath = this.pictureData.origname.split('/')[ this.pictureData.origname.split('/').length - 1 ];
   }
 
   increaseFrameSize() {


### PR DESCRIPTION
Die Teile der diplomatischen Umschrift sind nun in der richtigen Reihenfolge und daneben sind die richtigen Digitalisate. 
Über den Digitalisaten stehen die Seitennummern und die Originalnamen der Bilder.

Davon unabhängig ist die Auflösung der Digitalisate.

Zum Testen: ein paar Fassungen von Notiz- oder Manuskriptgedichten anschauen und schauen, ob die Seiten stimmen.