### PR TITLE
Nie 124: Link "Bezugstext"

### DIFF
--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.html
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.html
@@ -1,4 +1,0 @@
-<span *ngFor="let f of fassung; let i = index">
-  <a [routerLink]="['/' + f.konvolutTitle + '/' + f.title + '---' + f.iri]">{{ f.title }}</a><span
-  *ngIf="i+1 < fassung.length">,</span>
-</span>

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.ts
@@ -17,6 +17,7 @@ export class FassungSteckbriefFassungComponent implements OnChanges {
   fassung: Array<any>;
 
   private sub: any;
+  private sub2: any;
 
   constructor(private http: Http) {}
 
@@ -31,8 +32,24 @@ export class FassungSteckbriefFassungComponent implements OnChanges {
             let iriPart = this.fassungIRI[ i ].split('raeber/')[ 1 ];
             // TODO get convolute title for linking
             this.fassung.push({ 'konvolutTitle': 'hoffnung', 'title': title, 'iri': iriPart });
+            console.log(res);
           });
 
+        this.sub2 = this.http.get(globalSearchVariableService.API_URL + '/search/'
+          + '?searchtype=extended&property_id='
+          + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#Poem')
+          + '&property_id=' + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#hasPoemIRI')
+          + '&compop=EQ&searchval=' + encodeURIComponent(this.fassungIRI[i])
+          + '&property_id=' + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#hasConvoluteTitle')
+          + '&compop=EXISTS&searchval=')
+          .map(results => results.json())
+          .subscribe(res => {
+            for (let j = 0; j < this.fassung.length; j++) {
+              if (this.fassung[j]['pageIRI'] = this.fassungIRI[j]) {
+                this.fassung[j]['konvolutTitle'] = res.subjects[ 0 ].values[ 1 ];
+              }
+            }
+          });
       }
     }
   }

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.ts
@@ -1,56 +1,55 @@
 /**
  * Created by retobaumgartner on 10.10.17.
  */
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { Http } from '@angular/http';
 import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
 
 @Component({
   moduleId: module.id,
   selector: 'rae-fassung-steckbrief-fassung',
-  templateUrl: 'fassung-steckbrief-fassung.component.html'
+  template: '<a [routerLink]="[\'/\' + linkPartConv + \'/\' + linkPartPoem]"'
+  + ' (click)="goToOtherFassung.emit(\'/\' + linkPartConv + \'/\' + linkPartPoem)">{{ linkText }}</a>'
 })
 export class FassungSteckbriefFassungComponent implements OnChanges {
 
-  @Input() fassungIRI: Array<string>;
+  @Input() fassungIRI: string;
+  @Input() linkText: string;
+  @Output() goToOtherFassung: EventEmitter<any> = new EventEmitter<any>();
 
-  fassung: Array<any>;
+  linkPartPoem: string;
+  linkPartConv: string;
 
   private sub: any;
   private sub2: any;
 
-  constructor(private http: Http) {}
+  constructor(private http: Http) {
+  }
 
   ngOnChanges() {
     if (this.fassungIRI) {
-      for (let i = 0; i < this.fassungIRI.length; i++) {
-        this.sub = this.http.get(globalSearchVariableService.API_URL + '/resources/' +
-          encodeURIComponent(this.fassungIRI[ i ]))
-          .map(result => result.json())
-          .subscribe(res => {
-            let title = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
-            let iriPart = this.fassungIRI[ i ].split('raeber/')[ 1 ];
-            // TODO get convolute title for linking
-            this.fassung.push({ 'konvolutTitle': 'hoffnung', 'title': title, 'iri': iriPart });
-            console.log(res);
-          });
+      this.sub = this.http.get(globalSearchVariableService.API_URL + '/resources/' +
+        encodeURIComponent(this.fassungIRI))
+        .map(result => result.json())
+        .subscribe(res => {
+          let title = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str.split('/')[ 0 ];
+          let iriPart = this.fassungIRI.split('raeber/')[ 1 ];
+          this.linkPartPoem = title + '---' + iriPart;
+        });
 
-        this.sub2 = this.http.get(globalSearchVariableService.API_URL + '/search/'
-          + '?searchtype=extended&property_id='
-          + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#Poem')
-          + '&property_id=' + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#hasPoemIRI')
-          + '&compop=EQ&searchval=' + encodeURIComponent(this.fassungIRI[i])
-          + '&property_id=' + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#hasConvoluteTitle')
-          + '&compop=EXISTS&searchval=')
-          .map(results => results.json())
-          .subscribe(res => {
-            for (let j = 0; j < this.fassung.length; j++) {
-              if (this.fassung[j]['pageIRI'] = this.fassungIRI[j]) {
-                this.fassung[j]['konvolutTitle'] = res.subjects[ 0 ].values[ 1 ];
-              }
-            }
-          });
-      }
+      this.sub2 = this.http.get(globalSearchVariableService.API_URL + '/search/'
+        + '?searchtype=extended'
+        + '&filter_by_restype=' + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#Poem')
+        + '&property_id=' + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#hasPoemIRI')
+        + '&compop=EQ'
+        + '&searchval=' + encodeURIComponent(this.fassungIRI)
+        + '&property_id=' + encodeURIComponent('http://www.knora.org/ontology/kuno-raeber-gui#hasConvoluteTitle')
+        + '&compop=EXISTS'
+        + '&searchval=')
+        .map(results => results.json())
+        .subscribe(res => {
+          this.linkPartConv = res.subjects[ 0 ].value[ 1 ];
+        });
     }
   }
 }

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
@@ -101,11 +101,15 @@
         <span class="itemExtraFieldsValue">ja</span>
       </p>
     </li>
-    <li *ngIf="referencePoemIRIs && referencePoemIRIs.length > 0" class="typeSelect group2">
+    <li *ngIf="referencePoemIRI && referenceTitle" class="typeSelect group2">
       <p>
         <span class="itemExtraFieldsLabel">Bezugstext:</span>
         <span class="itemExtraFieldsValue">
-          <rae-fassung-steckbrief-fassung [fassungIRI]="referencePoemIRIs"></rae-fassung-steckbrief-fassung>
+          <rae-fassung-steckbrief-fassung
+            [fassungIRI]="referencePoemIRI"
+            [linkText]="referenceTitle"
+            (goToOtherFassung) = "goToOtherFassung.emit($event)">
+          </rae-fassung-steckbrief-fassung>
         </span>
       </p>
     </li>

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
@@ -58,36 +58,6 @@
         <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Textnr.:</span>
         <span  [innerHtml]="publicationNumber"></span>
     </li>
-
-<<<<<<< HEAD
-    <li *ngIf="hasStrophen" class="typeSelect group2">
-      <p>
-        <span class="itemExtraFieldsLabel">Strophen:</span>
-        <span class="itemExtraFieldsValue">ja</span>
-      </p>
-    </li>
-    <li *ngIf="isPartOfCycle" class="typeSelect group2">
-      <p>
-        <span class="itemExtraFieldsLabel">Zyklus:</span>
-        <span class="itemExtraFieldsValue">ja</span>
-      </p>
-    </li>
-    <li *ngIf="isInDialect" class="typeSelect group2">
-      <p>
-        <span class="itemExtraFieldsLabel">Mundart:</span>
-        <span class="itemExtraFieldsValue">ja</span>
-      </p>
-    </li>
-    <li *ngIf="referencePoemIRI && referenceTitle" class="typeSelect group2">
-      <p>
-        <span class="itemExtraFieldsLabel">Bezugstext:</span>
-        <span class="itemExtraFieldsValue">
-          <rae-fassung-steckbrief-fassung
-            [fassungIRI]="referencePoemIRI"
-            [linkText]="referenceTitle"
-            (goToOtherFassung) = "goToOtherFassung.emit($event)">
-          </rae-fassung-steckbrief-fassung>
-=======
     <li style="padding-bottom:5px;" *ngIf="hasStrophen" >
         <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Strophen:</span>
         <span >ja</span>
@@ -100,11 +70,14 @@
         <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Mundart:</span>
         <span >ja</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="referencePoemIRIs && referencePoemIRIs.length > 0" >
+    <li style="padding-bottom:5px;" *ngIf="referencePoemIRI && referenceTitle" >
         <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Bezugstext:</span>
         <span >
-          <rae-fassung-steckbrief-fassung [fassungIRI]="referencePoemIRIs"></rae-fassung-steckbrief-fassung>
->>>>>>> origin/master
+          <rae-fassung-steckbrief-fassung
+            [fassungIRI]="referencePoemIRI"
+            [linkText]="referenceTitle"
+            (goToOtherFassung) = "goToOtherFassung.emit($event)">
+          </rae-fassung-steckbrief-fassung>
         </span>
     </li>
     <li style="padding-bottom:5px;" *ngIf="isWrittenWith" >

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
@@ -2,7 +2,7 @@
  * Created by Reto Baumgartner (rfbaumgartner) on 05.07.17.
  */
 
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { Http } from '@angular/http';
 import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
 
@@ -14,6 +14,7 @@ import { globalSearchVariableService } from '../../suche/globalSearchVariablesSe
 export class FassungSteckbriefComponent implements OnChanges {
   @Input() fassungIRI: string;
   @Input() konvolutIRI: string;
+  @Output() goToOtherFassung: EventEmitter<any> = new EventEmitter<any>();
 
   isWrittenWith: string;
   specialDescription: string;
@@ -29,9 +30,10 @@ export class FassungSteckbriefComponent implements OnChanges {
   isInDialect: boolean;
   nachlassPublicationDescription: string;
   publicationNumber: string;
+  referenceTitle: string;
+  referencePoemIRI: string;
   unauthorizedPublication: Array<string>;
   publishedIn: Array<string>;
-  referencePoemIRIs: Array<string>;
 
   carrierIRIs: Array<string>;
 
@@ -55,8 +57,6 @@ export class FassungSteckbriefComponent implements OnChanges {
   }
 
   ngOnChanges() {
-    console.log("Fassungs-IRI: " +  this.fassungIRI);
-    console.log("Konvolut-IRI: " + this.konvolutIRI);
     if (this.fassungIRI) {
       this.sub = this.http.get(globalSearchVariableService.API_URL
         + '/resources/' + encodeURIComponent(this.fassungIRI))
@@ -158,6 +158,20 @@ export class FassungSteckbriefComponent implements OnChanges {
             this.publicationNumber = null;
           }
 
+          try {
+            this.referenceTitle =
+              res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasReferenceTitle' ].values[ 0 ].utf8str;
+          } catch (TypeError) {
+            this.referenceTitle = null;
+          }
+
+          try {
+            this.referencePoemIRI =
+              res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasReferencePoem' ].values[ 0 ];
+          } catch (TypeError) {
+            this.referencePoemIRI = null;
+          }
+
           this.unauthorizedPublication = [];
           try {
             for (let i = 0; i <
@@ -178,17 +192,6 @@ export class FassungSteckbriefComponent implements OnChanges {
             }
           } catch (TypeError) {
             // skip if there is no same edition
-          }
-
-          this.referencePoemIRIs = [];
-          try {
-            for (let i = 0; i <
-            res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasReferencePoem' ].values.length; i++) {
-              this.referencePoemIRIs
-                .push(res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasReferencePoem' ].values[ i ]);
-            }
-          } catch (TypeError) {
-            // skip if there is no bezugstext
           }
 
           this.carrierIRIs = [];

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -76,15 +76,10 @@
                         </md-card-footer>
                       </md-card>
                     </div>
-<<<<<<< HEAD
-                    <div class="itemExtraFields">
+                    <div style="margin-top:20px;">
                       <rae-fassung-steckbrief [fassungIRI]="urlPrefix + poem_id"
                                               [konvolutIRI]="konvolutIRI"
                                               (goToOtherFassung) = "goToOtherFassung($event)">
-=======
-                    <div style="margin-top:20px;">
-                      <rae-fassung-steckbrief [fassungIRI]="urlPrefix + poem_id" [konvolutIRI]="konvolutIRI">
->>>>>>> origin/master
                       </rae-fassung-steckbrief>
                     </div>
                   </div>

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -74,7 +74,9 @@
                       </md-card>
                     </div>
                     <div class="itemExtraFields">
-                      <rae-fassung-steckbrief [fassungIRI]="urlPrefix + poem_id" [konvolutIRI]="konvolutIRI">
+                      <rae-fassung-steckbrief [fassungIRI]="urlPrefix + poem_id"
+                                              [konvolutIRI]="konvolutIRI"
+                                              (goToOtherFassung) = "goToOtherFassung($event)">
                       </rae-fassung-steckbrief>
                     </div>
                   </div>


### PR DESCRIPTION
As soon as the rdf-links are there, the commenting text for a "Bezugstext" will be visible in its field with the link to the Fassung behind it.

Clicking on the link should navigate (the usual problem in "Fassungen" should work already.

Without the "Bezugstext" AND the link in Knora, no field should be shown.

Possible poems to test it are the 'Escorial' poems in Abgewandt-Zugewandt that correspond to Swiss resp. Standard German.