### PR TITLE
Fassungsansicht: V.a. Anpassungen an UI und UX

### DIFF
--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-konvolut.component.html
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-konvolut.component.html
@@ -1,4 +1,4 @@
 <span *ngFor="let pub of publications; let i = index">
-  <a [routerLink]="['/' + konvolutTypeMap[pub['type']] + '/' + pub['alias']]">{{ pub['title'] }}</a><span
+  {{ pub['title'] }}<span
   *ngIf="i+1 < publications.length">,</span>
 </span>

--- a/src/client/app/fassung/fassung-weitere/fassung-weitere.component.html
+++ b/src/client/app/fassung/fassung-weitere/fassung-weitere.component.html
@@ -4,7 +4,8 @@
   <li *ngIf="p !== undefined && !router.url.includes(p.split('###')[0].split('---')[1])">
     <a [routerLink]="[p.split('###')[0]]" routerLinkActive="active" (click)="goToOtherFassung(p.split('###')[0])">
       {{p.split('###')[1]}}
-    </a>
+    </a> <br/>
+    in : {{p.split('###')[0].split('/')[1]}}
   </li>
   </ng-container>
 </ul>

--- a/src/client/app/fassung/fassung.component.css
+++ b/src/client/app/fassung/fassung.component.css
@@ -12,6 +12,10 @@ div.itemFullText md-card md-card-footer button {
   text-align: left;
 }
 
+div.itemFullText md-card md-card-header button {
+  width: 100%;
+  text-align: left;
+}
 #rae-toolbar {
   text-align: right;
 }

--- a/src/client/app/fassung/fassung.component.css
+++ b/src/client/app/fassung/fassung.component.css
@@ -1,13 +1,10 @@
 .rae-fassung-resizable {
-  resize: vertical;
-  overflow-y: hidden;
-  border-bottom-color: silver;
-  border-bottom-style: solid;
-  border-bottom-width: 1px;
 }
 
 .rae-fassung-nonresizable {
-
+  height: 280px;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 div.itemFullText md-card md-card-footer button {

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -7,6 +7,8 @@
             <div id="rt-mainbody">
               <div class="component-content">
 
+                <span>Aktuelle Seite: {{konvolutType}} <a [routerLink]="">{{konvolutTitel}}</a></span>
+
                 <div id="rae-toolbar">
                   <rae-fassung-werkzeugleiste
                     (goToOtherFassung)="goToOtherFassung($event)"

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -43,8 +43,16 @@
                     <!-- Item text -->
                     <div class="itemFullText">
 
-                      <md-card>
-                        <md-card-content
+                      <md-card style="padding-top:0;">
+                        <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
+                                        *ngIf="zeigeKonstituiert">
+                          <button md-button (click)="zeigeKonstituiert = !zeigeKonstituiert"
+                                  style="background-color:#eee;">
+                            <md-icon>{{zeigeKonstituiert ? 'expand_more' : 'expand_less'}}</md-icon>
+                            <span>Text {{zeigeKonstituiert ? 'verbergen' : 'anzeigen'}}</span>
+                          </button>
+                        </md-card-header>
+                        <md-card-content style="padding-top:20px; padding-bottom:5px;"
                           *ngIf="zeigeKonstituiert"
                           [ngClass]="{'rae-fassung-resizable': poem_resizable, 'rae-fassung-nonresizable': !poem_resizable}">
                           <section class="edtext edtext_hs">
@@ -52,28 +60,36 @@
                           </section>
                         </md-card-content>
                         <md-card-footer>
-                          <button md-button (click)="zeigeKonstituiert = !zeigeKonstituiert">
-                            <md-icon *ngIf="zeigeKonstituiert">expand_less</md-icon>
-                            <md-icon *ngIf="!zeigeKonstituiert">expand_more</md-icon>
-                            <span *ngIf="zeigeKonstituiert">Text verbergen</span>
-                            <span *ngIf="!zeigeKonstituiert">Text anzeigen</span>
+                          <button md-button (click)="zeigeKonstituiert = !zeigeKonstituiert"
+                                  style="background-color:#eee;">
+                            <md-icon>{{zeigeKonstituiert ? 'expand_less' : 'expand_more'}}</md-icon>
+                            <span>Text {{zeigeKonstituiert ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
                         </md-card-footer>
                       </md-card>
+                      <br/>
 
-                      <md-card *ngIf="konvolutType === 'PoemManuscriptConvolute' || konvolutType === 'PoemNotebook'">
-                        <md-card-content *ngIf="zeigeDiplomatisch">
+                      <md-card *ngIf="konvolutType === 'PoemManuscriptConvolute' || konvolutType === 'PoemNotebook'"
+                               style="padding-top:0;">
+                        <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
+                                        *ngIf="zeigeDiplomatisch">
+                          <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch"
+                                  style="background-color:#eee;">
+                            <md-icon>{{zeigeDiplomatisch ? 'expand_more' : 'expand_less'}}</md-icon>
+                            <span>Diplomatische Umschrift {{zeigeDiplomatisch ? 'verbergen' : 'anzeigen'}}</span>
+                          </button>
+                        </md-card-header>
+                        <md-card-content *ngIf="zeigeDiplomatisch" style="padding-top:20px; padding-bottom:5px;">
                           <rae-fassung-diplomatisch [diplomaticIRIs]="diplomaticIRIs"
                                                     (pictureReduced)="show_register = true;"
                                                     (pictureIncreased)="show_register = false;">
                           </rae-fassung-diplomatisch>
                         </md-card-content>
                         <md-card-footer>
-                          <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch">
-                            <md-icon *ngIf="zeigeDiplomatisch">expand_less</md-icon>
-                            <md-icon *ngIf="!zeigeDiplomatisch">expand_more</md-icon>
-                            <span *ngIf="zeigeDiplomatisch">Diplomatische Umschrift verbergen</span>
-                            <span *ngIf="!zeigeDiplomatisch">Diplomatische Umschrift anzeigen</span>
+                          <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch"
+                                  style="background-color:#eee;">
+                            <md-icon>{{zeigeDiplomatisch ? 'expand_less' : 'expand_more'}}</md-icon>
+                            <span>Diplomatische Umschrift {{zeigeDiplomatisch ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
                         </md-card-footer>
                       </md-card>

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -7,7 +7,7 @@
             <div id="rt-mainbody">
               <div class="component-content">
 
-                <span>Aktuelle Seite: {{konvolutType}} <a [routerLink]="">{{konvolutTitel}}</a></span>
+                <span>Aktuelle Seite: {{konvolutTypeName}} > <a [routerLink]="">{{konvolutTitel}}</a></span>
 
                 <div id="rae-toolbar">
                   <rae-fassung-werkzeugleiste

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -7,7 +7,7 @@
             <div id="rt-mainbody">
               <div class="component-content">
 
-                <span>Aktuelle Seite: {{konvolutTypeName}} > <a [routerLink]="">{{konvolutTitel}}</a></span>
+                <span>Aktuelle Seite: {{konvolutTypeName}} > <a [routerLink]="konvolutLink">{{konvolutTitel}}</a></span>
 
                 <div id="rae-toolbar">
                   <rae-fassung-werkzeugleiste

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -72,8 +72,8 @@
                           <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch">
                             <md-icon *ngIf="zeigeDiplomatisch">expand_less</md-icon>
                             <md-icon *ngIf="!zeigeDiplomatisch">expand_more</md-icon>
-                            <span *ngIf="zeigeDiplomatisch">Diplomatischen Text verbergen</span>
-                            <span *ngIf="!zeigeDiplomatisch">Diplomatischen Text anzeigen</span>
+                            <span *ngIf="zeigeDiplomatisch">Diplomatische Umschrift verbergen</span>
+                            <span *ngIf="!zeigeDiplomatisch">Diplomatische Umschrift anzeigen</span>
                           </button>
                         </md-card-footer>
                       </md-card>

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -42,6 +42,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   konvolutType: string;
   konvolutIRI: string;
   konvolutTitel: string;
+  konvolutLink: string;
   synopseIRI: string;
   workTitle: string;
   otherWorkExpressions: any[] = [];
@@ -60,7 +61,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   private static produceFassungsLink(titel: string, iri: string) {
     if (titel !== undefined && iri !== undefined) {
-      return titel.split('/')[ 0 ] + '---' + iri.split('raeber/')[ 1 ];
+      return titel.split('/')[0] + '---' + iri.split('raeber/')[1];
     } else {
       return 'Linkinformation has not arrived yet';
     }
@@ -69,9 +70,35 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   ngOnInit() {
     this.poem_resizable = true;
     this.show_register = true;
-    this.konvolutTitel = decodeURIComponent(this.router.url.split('/')[ 1 ]);
-    this.poem_id = this.router.url.split('/')[ 2 ].split('---')[ 1 ];
+    this.konvolutTitel = decodeURIComponent(this.router.url.split('/')[1]);
+    this.poem_id = this.router.url.split('/')[2].split('---')[1];
     this.updateView();
+
+    if (this.konvolutTitel.includes('Notizbuch')) {
+      this.konvolutLink = '/notizbuecher/notizbuch-' + this.konvolutTitel.split(' ')[1];
+    } else if (this.konvolutTitel.includes('manuskripte')) {
+      this.konvolutLink = '/manuskripte/manuskripte-' + this.konvolutTitel.split(' ')[1];
+    } else if (this.konvolutTitel.includes('Typoskript')) {
+      this.konvolutLink = '/typoskripte/typoskripte-' + this.konvolutTitel.split(' ')[1];
+    } else {
+      if (this.konvolutTitel === 'GESICHT IM MITTAG 1950') {
+        this.konvolutLink = '/drucke/gesicht-im-mittag';
+      } else if (this.konvolutTitel === 'Die verwandelten Schiffe 1957') {
+        this.konvolutLink = '/drucke/die-verwandelten-schiffe';
+      } else if (this.konvolutTitel === 'GEDICHTE 1960') {
+        this.konvolutLink = '/drucke/gedichte';
+      } else if (this.konvolutTitel === 'FLUSSUFER 1963') {
+        this.konvolutLink = '/drucke/flussufer';
+      } else if (this.konvolutTitel === 'Reduktionen 1981') {
+        this.konvolutLink = '/drucke/reduktionen';
+      } else if (this.konvolutTitel === 'Hochdeutsche Gedichte 1985') {
+        this.konvolutLink = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
+      } else if (this.konvolutTitel === 'Alemannische Gedichte 1985') {
+        this.konvolutLink = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
+      } else {
+        this.konvolutLink = '/drucke/verstreutes';
+      }
+    }
   }
 
   updateView() {

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -17,7 +17,7 @@ import { DateFormatService } from '../shared/utilities/date-format.service';
   moduleId: module.id,
   selector: 'rae-fassung',
   templateUrl: 'fassung.component.html',
-  styleUrls: ['fassung.component.css']
+  styleUrls: [ 'fassung.component.css' ]
 })
 export class FassungComponent implements OnInit, AfterViewChecked {
   creationDate: string;
@@ -47,6 +47,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   otherWorkExpressions: any[] = [];
   otherWorkExpressionsIri: string[];
 
+  konvolutTypeName: string;
+
   nextPoem: string = '';
   prevPoem: string = '';
 
@@ -58,7 +60,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   private static produceFassungsLink(titel: string, iri: string) {
     if (titel !== undefined && iri !== undefined) {
-      return titel.split('/')[0] + '---' + iri.split('raeber/')[1];
+      return titel.split('/')[ 0 ] + '---' + iri.split('raeber/')[ 1 ];
     } else {
       return 'Linkinformation has not arrived yet';
     }
@@ -67,8 +69,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   ngOnInit() {
     this.poem_resizable = true;
     this.show_register = true;
-    this.konvolutTitel = decodeURIComponent(this.router.url.split('/')[1]);
-    this.poem_id = this.router.url.split('/')[2].split('---')[1];
+    this.konvolutTitel = decodeURIComponent(this.router.url.split('/')[ 1 ]);
+    this.poem_id = this.router.url.split('/')[ 2 ].split('---')[ 1 ];
     this.updateView();
   }
 
@@ -79,33 +81,38 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .map(result => result.json())
       .subscribe(res => {
         console.log(res);
-        this.poemTitle = res.props['http://www.knora.org/ontology/text#hasTitle'].values[0].utf8str;
-        this.textEdition = res.props['http://www.knora.org/ontology/kuno-raeber#hasEdition'].values[0];
+        this.poemTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
+        this.textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];
         this.getEditedPoemText(this.textEdition);
-        this.pageIRIs = res.props['http://www.knora.org/ontology/kuno-raeber#isOnPage'].values;
-        this.diplomaticIRIs = res.props['http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription'].values;
-        this.poemSeqnum = res.props['http://www.knora.org/ontology/knora-base#seqnum'].values[0];
-        this.creationDate = this.dfs.germanLongDate(res.props['http://www.knora.org/ontology/human#hasCreationDate'].values[0].dateval1);
-        this.modificationDate = this.dfs.germanLongDate(res.props['http://www.knora.org/ontology/human#hasModificationDate'].values[0].utf8str);
-        this.poemConvoluteType = res.resdata['restype_name'].split('#')[1];
+        this.pageIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isOnPage' ].values;
+        this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
+        this.poemSeqnum = res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ];
+        this.creationDate = this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1);
+        this.modificationDate = this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasModificationDate' ].values[ 0 ].utf8str);
+        this.poemConvoluteType = res.resdata[ 'restype_name' ].split('#')[ 1 ];
         switch (this.poemConvoluteType) {
           case 'PoemNote':
             this.convoluteProperty = 'http://www.knora.org/ontology/kuno-raeber#isInNotebook';
+            this.konvolutTypeName = 'Notizbuch';
             break;
           case 'HandwrittenPoem':
             this.convoluteProperty = 'http://www.knora.org/ontology/text#isInManuscript';
+            this.konvolutTypeName = 'Manuskript';
             break;
           case 'PostCardPoem':
             this.convoluteProperty = 'http://www.knora.org/ontology/text#isOnPostcard';
+            this.konvolutTypeName = 'Manuskript';
             break;
           case 'TypewrittenPoem':
             this.convoluteProperty = 'http://www.knora.org/ontology/text#isInTypescript';
+            this.konvolutTypeName = 'Typoskript';
             break;
           case 'PublicationPoem':
             this.convoluteProperty = 'http://www.knora.org/ontology/work#isPublishedIn';
+            this.konvolutTypeName = 'DRUCK';
             break;
         }
-        this.poemConvoluteIri = res.props[this.convoluteProperty].values[0];
+        this.poemConvoluteIri = res.props[ this.convoluteProperty ].values[ 0 ];
         this.getPrevNextPoems(this.poemSeqnum);
       });
 
@@ -115,17 +122,17 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .subscribe(res => {
         for (const r of res.nodes) {
           //console.log(r);
-          if (r['resourceClassIri'].split('#')[1] === ('PoemNotebook' ||
+          if (r[ 'resourceClassIri' ].split('#')[ 1 ] === ('PoemNotebook' ||
               'PoemManuscriptConvolute' ||
               'PoemPostcardConvolute' ||
               'PoemTypescriptConvolute' ||
               'PrintedPoemBookPublication' ||
               'PolyAuthorPublication')) {
             //this.konvolutIRI = r[ 'resourceIri' ];
-            this.konvolutType = r['resourceClassIri'].split('#')[1];
+            this.konvolutType = r[ 'resourceClassIri' ].split('#')[ 1 ];
           }
-          if (r['resourceClassIri'].split('#')[1] === 'Work') {
-            this.synopseIRI = r['resourceIri'];
+          if (r[ 'resourceClassIri' ].split('#')[ 1 ] === 'Work') {
+            this.synopseIRI = r[ 'resourceIri' ];
             this.getWork(this.synopseIRI);
           }
         }
@@ -146,13 +153,13 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .map(result => result.json())
       .subscribe(res => {
         console.log(res.subjects);
-        console.log(res.subjects[0].value[1]);
-        this.konvolutIRI = res.subjects[0].value[1];
+        console.log(res.subjects[ 0 ].value[ 1 ]);
+        this.konvolutIRI = res.subjects[ 0 ].value[ 1 ];
       });
   }
 
   goToOtherFassung(idOfFassung: string) {
-    const tempPoemId = idOfFassung.split('---')[1];
+    const tempPoemId = idOfFassung.split('---')[ 1 ];
     this.poem_id = tempPoemId !== undefined && !tempPoemId.includes('/') ? tempPoemId : this.poem_id;
     this.updateView();
   }
@@ -164,14 +171,14 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   private getEditedPoemText(editedTextIri: string) {
     this.http.get(Config.API + 'resources/' + encodeURIComponent(editedTextIri))
       .map(result => result.json())
-      .subscribe(res => this.editedPoemText = res.props['http://www.knora.org/ontology/text#hasContent'].values[0].utf8str);
+      .subscribe(res => this.editedPoemText = res.props[ 'http://www.knora.org/ontology/text#hasContent' ].values[ 0 ].utf8str);
   }
 
   private getWork(workIri: string) {
     this.http.get(Config.API + 'resources/' + encodeURIComponent(workIri))
       .map(result => result.json())
       .subscribe(res => {
-        this.workTitle = res.props['http://www.knora.org/ontology/text#hasTitle'].values[0].utf8str;
+        this.workTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
       });
     const request = globalSearchVariableService.API_URL +
       globalSearchVariableService.extendedSearch +
@@ -202,8 +209,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       '&compop=EXISTS' +
       '&searchval=' +
       /*'&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSameEditionAs' +
-      '&compop=EXISTS' +
-      '&searchval=' +*/
+       '&compop=EXISTS' +
+       '&searchval=' +*/
       '&show_nrows=2000';
     return this.http.get(
       request
@@ -212,11 +219,11 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         (lambda: Response) => lambda.json()
       )
       .subscribe(response => {
-        this.otherWorkExpressions = [];
+          this.otherWorkExpressions = [];
           for (let res of response.subjects) {
-            this.otherWorkExpressions.push('/' + res.value[3] + '/' +
-              FassungComponent.produceFassungsLink(res.value[7], res.value[5]) +
-              '###' + res.value[7]);
+            this.otherWorkExpressions.push('/' + res.value[ 3 ] + '/' +
+              FassungComponent.produceFassungsLink(res.value[ 7 ], res.value[ 5 ]) +
+              '###' + res.value[ 7 ]);
           }
         }
       );
@@ -237,19 +244,19 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .map(result => result.json())
       .subscribe(res => {
         console.log(res);
-        if (res.subjects[0]) {
-          let poemIri = res.subjects[0]['obj_id'];
+        if (res.subjects[ 0 ]) {
+          let poemIri = res.subjects[ 0 ][ 'obj_id' ];
           console.log(poemIri);
-          this.prevPoem = poemIri.split('/')[4];
+          this.prevPoem = poemIri.split('/')[ 4 ];
           this.http.get(Config.API + 'resources/' + encodeURIComponent(poemIri))
             .map(result => result.json())
             .subscribe(res => {
               if (res.nhits !== '0') {
                 console.log(this.konvolutTitel);
                 this.prevPoem = '/' + this.konvolutTitel + '/' +
-                  encodeURIComponent(res.props['http://www.knora.org/ontology/text#hasTitle'].values[0].utf8str) +
+                  encodeURIComponent(res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str) +
                   '---' + this.prevPoem + '###' +
-                  res.props['http://www.knora.org/ontology/text#hasTitle'].values[0].utf8str;
+                  res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
                 console.log(this.prevPoem);
               } else {
                 this.prevPoem = '###';
@@ -260,19 +267,19 @@ export class FassungComponent implements OnInit, AfterViewChecked {
     this.http.get(searchParamsNext.toString())
       .map(result => result.json())
       .subscribe(res => {
-        if (res.subjects[0]) {
-          let poemIri = res.subjects[0]['obj_id'];
+        if (res.subjects[ 0 ]) {
+          let poemIri = res.subjects[ 0 ][ 'obj_id' ];
           console.log(poemIri);
-          this.nextPoem = poemIri.split('/')[4];
+          this.nextPoem = poemIri.split('/')[ 4 ];
           this.http.get(Config.API + 'resources/' + encodeURIComponent(poemIri))
             .map(result => result.json())
             .subscribe(res => {
               if (res.nhits !== '0') {
                 console.log(this.konvolutTitel);
                 this.nextPoem = '/' + this.konvolutTitel + '/' +
-                  encodeURIComponent(res.props['http://www.knora.org/ontology/text#hasTitle'].values[0].utf8str) +
+                  encodeURIComponent(res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str) +
                   '---' + this.nextPoem + '###' +
-                  res.props['http://www.knora.org/ontology/text#hasTitle'].values[0].utf8str;
+                  res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
                 console.log(this.nextPoem);
               } else {
                 this.prevPoem = '###';

--- a/src/client/app/shared/registerspalte/registerspalte.component.html
+++ b/src/client/app/shared/registerspalte/registerspalte.component.html
@@ -6,8 +6,8 @@
   </md-button-toggle-group>
   <md-nav-list dense>
     <a md-list-item *ngFor="let p of poems; let i = index"
-       [routerLink]="['/' + this.konvolutTitle + '/'] + produceFassungsLink(p.title,p.iri)"
-       (click)="goToOtherFassung.emit('/' + konvolutTitle + '/' + produceFassungsLink(p.title,p.iri))"
+       [routerLink]="['/' + this.konvolutTitle + '/'] + produceFassungsLink(p)"
+       (click)="goToOtherFassung.emit('/' + konvolutTitle + '/' + produceFassungsLink(p))"
        routerLinkActive="active">
 
       <h5 md-line *ngIf="p">{{ p[0] }}</h5>


### PR DESCRIPTION
Zu testen:
- Breadcrumbs oben stimmen
- Textfeld für konstituierten Text hat bei "fixer Höhe" konstante Höhe (auch bei Navigation durch Fassungen), bei "angepasster Höhe" ändert sich diese für jede Fassung
- Weiter Informationen: Letzter Druck -> Kein Link mehr
- Weitere Fassungen: Informationen zu Konvolut hinzugefügt
- Layout Textfelder: Wenn Karte geöffnet wird, kommt neu noch ein Header hinzu, mit welchem die Karte ebenfalls wieder geschlossen werden kann