### PR TITLE
Finalisiere diplomatisch

### DIFF
--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -22,7 +22,9 @@
     <div *ngIf="p['diplIRI'] && showPage[i]" style="display: inline-block; vertical-align: top">
       <rae-diplomatischer-text [textIRI]="p['diplIRI']"
                                [(gewaehlteSchicht)]="gewaehlteSchicht"
-                               [(textIsMovable)]="textIsMovable">
+                               [(textIsMovable)]="textIsMovable"
+                               [(showStufe1)]="showStufe1"
+                               [(showStufe2)]="showStufe2">
       </rae-diplomatischer-text>
     </div>
     <rae-fassung-diplomatisch-seiten [pageIRI]="p['pageIRI']"

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.html
@@ -1,14 +1,25 @@
 <div #diplomatischKarte>
-  <div *ngFor="let p of pages">
-    <div style="display: inline-block; vertical-align: top">
-      <h4><span>{{ p['pagenumber'] }}</span> <span>({{ p['origName'] }})</span> </h4>
-      <rae-image-frame *ngIf="p['picData']"
-        [pictureData]="p['picData']"
-        [initWidth]="cardWidth"
-        (pictureIncreased)="pictureIncreased.emit(null)"
-        (pictureReduced)="pictureReduced.emit(null)"></rae-image-frame>
+  <div *ngFor="let p of pages; let i = index">
+    <div>
+      <h4 style="display: inline-block;">{{ p['pagenumber'] }}</h4>
+      <button md-button
+              (click)="showPage[i] = !showPage[i]"
+              style="display: inline-block;">
+        <md-icon *ngIf="showPage[i]">clear</md-icon>
+        <md-icon *ngIf="!showPage[i]">add</md-icon>
+      </button>
     </div>
-    <div *ngIf="p['diplIRI']" style="display: inline-block; vertical-align: top">
+    <div *ngIf="showPage[i]" style="display: inline-block; vertical-align: top">
+
+      <rae-image-frame *ngIf="p['picData']"
+                       [origName]="p['origName']"
+                       [pictureData]="p['picData']"
+                       [initWidth]="cardWidth"
+                       (pictureIncreased)="pictureIncreased.emit(null)"
+                       (pictureReduced)="pictureReduced.emit(null)">
+      </rae-image-frame>
+    </div>
+    <div *ngIf="p['diplIRI'] && showPage[i]" style="display: inline-block; vertical-align: top">
       <rae-diplomatischer-text [textIRI]="p['diplIRI']"
                                [(gewaehlteSchicht)]="gewaehlteSchicht"
                                [(textIsMovable)]="textIsMovable">

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -24,6 +24,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
   pages: Array<any> = [];
   gewaehlteSchicht: string = 'schicht0';
   textIsMovable: boolean = false;
+  showPage: Array<boolean>;
 
   private sub: any;
 
@@ -31,6 +32,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
 
   ngOnChanges() {
     this.pages = [];
+    this.showPage = [];
 
     if (this.diplomaticIRIs) {
       for (let i = 0; i < this.diplomaticIRIs.length; i++) {
@@ -43,6 +45,7 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
           .subscribe(res => {
             try {
               seqnum = Number(res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ]);
+              this.showPage[ i ] = true;
             } catch (TypeError) {
               console.log('Cannot get seqnum for this page.');
               seqnum = 100;

--- a/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
+++ b/src/client/app/fassung/fassung-diplomatisch/fassung-diplomatisch.component.ts
@@ -25,6 +25,8 @@ export class FassungDiplomatischComponent implements OnChanges, AfterViewInit {
   gewaehlteSchicht: string = 'schicht0';
   textIsMovable: boolean = false;
   showPage: Array<boolean>;
+  showStufe1: boolean = false;
+  showStufe2: boolean = false;
 
   private sub: any;
 

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
@@ -4,15 +4,13 @@ md-button-toggle-group {
 
 md-button-toggle, button {
   width: 25%;
+  min-width: 10px;
   height: 36px;
   font-size: 80%;
 }
 
 button.rae-image-small-button {
-  min-width: 10px;
-  height: 30px;
   line-height: normal;
-  padding: 5px;
   font-size: 80%;
   vertical-align: middle;
 }

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
@@ -1,16 +1,17 @@
-md-button-toggle-group {
-  width: 80%;
-}
-
-md-button-toggle, button {
-  width: 25%;
-  min-width: 10px;
-  height: 36px;
-  font-size: 80%;
+menu {
+  margin: 0;
+  padding: 0;
 }
 
 button.rae-image-small-button {
+  min-width: 30px;
+  height: 30px;
   line-height: normal;
+  padding: 5px;
   font-size: 80%;
   vertical-align: middle;
+}
+
+.button-is-active {
+  background-color: silver;
 }

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
@@ -7,3 +7,12 @@ md-button-toggle, button {
   height: 36px;
   font-size: 80%;
 }
+
+button.rae-image-small-button {
+  min-width: 10px;
+  height: 30px;
+  line-height: normal;
+  padding: 5px;
+  font-size: 80%;
+  vertical-align: middle;
+}

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -1,5 +1,4 @@
 <div class="rae-diplomatic">
-  <md-toolbar>
     <md-button-toggle-group [(ngModel)]="gewaehlteSchicht" name="schichtwaehler{{textIRI}}"
                             (ngModelChange)="gewaehlteSchichtChange.emit(gewaehlteSchicht)">
       <md-button-toggle value="schicht0"
@@ -24,15 +23,15 @@
                         title="Endschicht (Basis für edierten Text)">
         3
       </md-button-toggle>
+
+      <button md-raised-button (click)="toggleDraggable()" title="Umschrift verschiebbar machen">
+        <md-icon *ngIf="textIsMovable">check_box</md-icon>
+        <md-icon *ngIf="!textIsMovable">check_box_outline_blank</md-icon>
+        ↔
+      </button>
+
     </md-button-toggle-group>
 
-    <button md-raised-button (click)="toggleDraggable()" title="Umschrift verschiebbar machen">
-      <md-icon *ngIf="textIsMovable">check_box</md-icon>
-      <md-icon *ngIf="!textIsMovable">check_box_outline_blank</md-icon>
-      ↔
-    </button>
-
-  </md-toolbar>
   <div class="umschrift edtext edtext_hs">
     <div class="transkription" [innerHtml]="text"></div>
   </div>

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -8,11 +8,13 @@
         0
       </md-button-toggle>
       <md-button-toggle value="schicht1"
+                        *ngIf="showStufe1"
                         [ngStyle]="{'color': farbeErste}"
                         title="Grundschicht (kleiner Verbund), nur ausnahmsweise ausgezeichnet">
         1
       </md-button-toggle>
       <md-button-toggle value="schicht2"
+                        *ngIf="showStufe2"
                         [ngStyle]="{'color': farbeEinfuegung}"
                         title="Texteinfügung entgegen dem linearen Verlauf der Niederschrift">
         2

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -1,36 +1,52 @@
 <div class="rae-diplomatic">
-    <md-button-toggle-group [(ngModel)]="gewaehlteSchicht" name="schichtwaehler{{textIRI}}"
-                            (ngModelChange)="gewaehlteSchichtChange.emit(gewaehlteSchicht)">
-      <md-button-toggle value="schicht0"
-                        [ngStyle]="{'color': farbeNeutral}"
-                        title="Anfangsschicht ohne Auszeichnung">
-        0
-      </md-button-toggle>
-      <md-button-toggle value="schicht1"
-                        *ngIf="showStufe1"
-                        [ngStyle]="{'color': farbeErste}"
-                        title="Grundschicht (kleiner Verbund), nur ausnahmsweise ausgezeichnet">
-        1
-      </md-button-toggle>
-      <md-button-toggle value="schicht2"
-                        *ngIf="showStufe2"
-                        [ngStyle]="{'color': farbeEinfuegung}"
-                        title="Texteinfügung entgegen dem linearen Verlauf der Niederschrift">
-        2
-      </md-button-toggle>
-      <md-button-toggle value="schicht3"
-                        [ngStyle]="{'color': farbeLetzte}"
-                        title="Endschicht (Basis für edierten Text)">
-        3
-      </md-button-toggle>
+  <menu>
 
-      <button md-raised-button (click)="toggleDraggable()" title="Umschrift verschiebbar machen">
-        <md-icon *ngIf="textIsMovable">check_box</md-icon>
-        <md-icon *ngIf="!textIsMovable">check_box_outline_blank</md-icon>
-        ↔
-      </button>
+    <button md-raised-button
+            [ngStyle]="{'color': farbeNeutral}"
+            [ngClass]="{'button-is-active': gewaehlteSchicht == 'schicht0'}"
+            class="rae-image-small-button"
+            title="Anfangsschicht ohne Auszeichnung"
+            (click)="gewaehlteSchicht = 'schicht0'; gewaehlteSchichtChange.emit(gewaehlteSchicht); updateSchichten();">
+      0
+    </button>
 
-    </md-button-toggle-group>
+    <button md-raised-button
+            [ngStyle]="{'color': farbeErste}"
+            [ngClass]="{'button-is-active': gewaehlteSchicht == 'schicht1'}"
+            class="rae-image-small-button"
+            *ngIf="showStufe1"
+            title="Grundschicht (kleiner Verbund), nur ausnahmsweise ausgezeichnet"
+            (click)="gewaehlteSchicht = 'schicht1'; gewaehlteSchichtChange.emit(gewaehlteSchicht); updateSchichten();">
+      1
+    </button>
+
+    <button md-raised-button
+            [ngStyle]="{'color': farbeEinfuegung}"
+            [ngClass]="{'button-is-active': gewaehlteSchicht == 'schicht2'}"
+            class="rae-image-small-button"
+            *ngIf="showStufe2"
+            title="Texteinfügung entgegen dem linearen Verlauf der Niederschrift"
+            (click)="gewaehlteSchicht = 'schicht2'; gewaehlteSchichtChange.emit(gewaehlteSchicht); updateSchichten();">
+      2
+    </button>
+
+    <button md-raised-button
+            [ngStyle]="{'color': farbeLetzte}"
+            [ngClass]="{'button-is-active': gewaehlteSchicht == 'schicht3'}"
+            class="rae-image-small-button"
+            title="Endschicht (Basis für edierten Text)"
+            (click)="gewaehlteSchicht = 'schicht3'; gewaehlteSchichtChange.emit(gewaehlteSchicht); updateSchichten();">
+      3
+    </button>
+
+    <button md-raised-button
+            (click)="toggleDraggable()"
+            [ngClass]="{'button-is-active': textIsMovable}"
+            class="rae-image-small-button"
+            title="Umschrift verschiebbar machen">
+      ↔
+    </button>
+  </menu>
 
   <div class="umschrift edtext edtext_hs">
     <div class="transkription" [innerHtml]="text"></div>

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
@@ -18,9 +18,14 @@ export class DimplomatischerTextComponent implements OnInit, DoCheck, OnChanges 
   @Input() gewaehlteSchicht: string;
   @Input() textIRI: string;
   @Input() textIsMovable: boolean;
+  @Input() showStufe1: boolean;
+  @Input() showStufe2: boolean;
 
   @Output() gewaehlteSchichtChange: EventEmitter<string> = new EventEmitter<string>();
   @Output() textIsMovableChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() showStufe1Change: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() showStufe2Change: EventEmitter<boolean> = new EventEmitter<boolean>();
+
 
   farbeNeutral = '#6e6e6e';
   farbeMarkierung = '#d00501';
@@ -63,6 +68,14 @@ export class DimplomatischerTextComponent implements OnInit, DoCheck, OnChanges 
         .subscribe(res => {
           this.text = res.props[ 'http://www.knora.org/ontology/text#hasContent' ].values[ 0 ].utf8str;
           this.updateSchichten();
+          if(this.text.match('schicht1')) {
+            this.showStufe1 = true;
+            this.showStufe1Change.emit(this.showStufe1);
+          }
+          if(this.text.match('einfuegung')) {
+            this.showStufe2 = true;
+            this.showStufe2Change.emit(this.showStufe2);
+          }
         });
     }
   }

--- a/src/client/app/shared/image-frame/image-frame.component.html
+++ b/src/client/app/shared/image-frame/image-frame.component.html
@@ -1,57 +1,26 @@
-<!--
-For the kitchen sink
-
-<br>
-<p>The Image Grid component</p>
-<br>
-<button md-raised-button (click)="searchForDoctor()">Search Resource with Image Example</button>
-<br/>
-<br/>
-<div class="rae-image-container" *ngFor="let image of myImages; let i = index">
-  {{ image.value[0] }}
-  <img id="{{ image.obj_id }}"
-       src="http://test-02.salsah.org/core/sendlocdata.php?res={{ image.obj_id }}&reduce={{ zoomfactor }}">
-  <button md-raised-button (click)="increaseSize()">Increase size</button>
-  <button md-raised-button (click)="reduceSize()">Reduce size</button>
-</div>
--->
-
 <div>
-  <md-card>
-    <md-card-content *ngIf="ausgeklappt">
-      <div [ngStyle]="{'height': height + px, 'width': width + px, 'overflow-y': overflow, 'resize': resize}" #picFrame>
-        <!--  <img src="http://test-02.salsah.org/core/sendlocdata.php?res=212767&qtype=full&reduce={{ zoomfactor }}"
-               class="rae-image_resizeable"> -->
-        <img src="{{ pictureIdBase }}{{ width }},/0/default.jpg" class="rae-image_resizeable">
-      </div>
 
-    </md-card-content>
+  <md-toolbar>
 
-    <md-card-content *ngIf="!ausgeklappt">
-      <div [ngStyle]="{'width': width + px}" #emptyPicFrame></div>
-    </md-card-content>
+    <button md-button class="rae-image-small-button" (click)="increaseFrameSize()" title="Bild vergrössern">
+      <md-icon>zoom_in</md-icon>
+    </button>
 
-    <md-card-footer>
-      <button md-button (click)="ausgeklappt = !ausgeklappt">
-        <md-icon *ngIf="ausgeklappt">expand_less</md-icon>
-        <md-icon *ngIf="!ausgeklappt">expand_more</md-icon>
-        <span *ngIf="ausgeklappt">Bild verbergen</span>
-        <span *ngIf="!ausgeklappt">Bild anzeigen</span>
-      </button>
+    <button md-button class="rae-image-small-button" (click)="reduceFrameSize()" title="Bild verkleinern">
+      <md-icon>zoom_out</md-icon>
+    </button>
 
-      <button md-button class="rae-image-small-button" (click)="increaseFrameSize()" title="Bild vergrössern">
-        <md-icon *ngIf="ausgeklappt">zoom_in</md-icon>
-      </button>
+    <button md-button class="rae-image-small-button" (click)="resetSize()" title="Neu laden">
+      <md-icon>cached</md-icon>
+    </button>
 
-      <button md-button class="rae-image-small-button" (click)="reduceFrameSize()" title="Bild verkleinern">
-        <md-icon *ngIf="ausgeklappt">zoom_out</md-icon>
-      </button>
+    <span>({{ origName }})</span>
 
-      <button md-button class="rae-image-small-button" (click)="resetSize()" title="Neu laden">
-        <md-icon *ngIf="ausgeklappt">cached</md-icon>
-      </button>
+  </md-toolbar>
 
-    </md-card-footer>
-  </md-card>
-
+  <div [ngStyle]="{'height': height + px, 'width': width + px, 'overflow-y': overflow, 'resize': resize}" #picFrame>
+    <!--  <img src="http://test-02.salsah.org/core/sendlocdata.php?res=212767&qtype=full&reduce={{ zoomfactor }}"
+           class="rae-image_resizeable"> -->
+    <img src="{{ pictureIdBase }}{{ width }},/0/default.jpg" class="rae-image_resizeable">
+  </div>
 </div>

--- a/src/client/app/shared/image-frame/image-frame.component.ts
+++ b/src/client/app/shared/image-frame/image-frame.component.ts
@@ -16,6 +16,7 @@ export class ImageFrameComponent implements OnInit {
 
   @Input() pictureData: any;
   @Input() initWidth: number;
+  @Input() origName: string;
 
   @Output() pictureReduced = new EventEmitter();
   @Output() pictureIncreased = new EventEmitter();
@@ -31,8 +32,6 @@ export class ImageFrameComponent implements OnInit {
   resize = 'both';
   px = 'px';
 
-  ausgeklappt: boolean = true;
-
   ngOnInit() {
     this.pictureIdBase = this.pictureData.path.split(this.pictureData.nx + ',' + this.pictureData.ny)[ 0 ];
     this.width = this.initWidth;
@@ -40,13 +39,13 @@ export class ImageFrameComponent implements OnInit {
   }
 
   increaseFrameSize() {
-    this.width += 40;
+    this.width += 200;
     this.height = Math.ceil(this.width * this.pictureData.ny / this.pictureData.nx);
     this.pictureIncreased.emit(null);
   }
 
   reduceFrameSize() {
-    this.width -= 40;
+    this.width -= 200;
     this.height = Math.ceil(this.width * this.pictureData.ny / this.pictureData.nx);
     this.pictureReduced.emit(null);
   }


### PR DESCRIPTION
Zum Testen:

- Statt "Bild verbergen" gibt es neben der Seitenzahl einen Button, mit dem die Seiten ein- und ausgeblendet werden können (mitsamt Umschrift). Neu oberhalb der Seite
- Die Buttons für die Bildmanipulation (Zoom) sind jetzt über dem Bild
- Die Vergrösserungsschritte sind grösser: 200px dazu/weg statt 40px
- Nur die Schichtbuttons, die in der Umschrift vertreten sind, tauchen jetzt auf. Der Rahmen um die Buttons ist weg. Noch sind die Buttons relativ gross, aber vielleicht reicht es auch so.
- Die Bildsignaturen sind jetzt über dem Bild bei den Zoom-Buttons