### PR TITLE
Duplikate in Synopsen

### DIFF
--- a/src/client/app/shared/fromPoemIRIToTextgridInformation/fromPoemIRIToTextgridInformation.component.ts
+++ b/src/client/app/shared/fromPoemIRIToTextgridInformation/fromPoemIRIToTextgridInformation.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { globalSearchVariableService } from '../../suche/globalSearchVariablesService';
-import { Config } from '../config/env.config';
 import { Router } from '@angular/router';
 
 @Component({
@@ -25,7 +24,7 @@ export class FromPoemIRIToTextgridInformationComponent implements OnChanges {
 
   ngOnChanges() {
     if (this.contentType === 'synopse') {
-      if(this.workIRI) console.log('Work iri to get Poems with Cache ' + this.workIRI);
+      if (this.workIRI) console.log('Work iri to get Poems with Cache ' + this.workIRI);
       this.poemInformation = [];
       this.countRequests = 0;
       this.performQuery();
@@ -37,8 +36,8 @@ export class FromPoemIRIToTextgridInformationComponent implements OnChanges {
     }
     //if (this.poemIRIArray !== undefined && this.poemIRIArray.length !== 0) {
     //  for (this.i = 0; this.i < this.poemIRIArray.length; this.i++) {
-        //console.log('get information for this poem:');
-        //this.getTitleAndDate(this.poemIRIArray[ this.i ], this.i);
+    //console.log('get information for this poem:');
+    //this.getTitleAndDate(this.poemIRIArray[ this.i ], this.i);
     //    this.poemInformation[ this.i ] = [];
     //  }
     //}
@@ -46,8 +45,8 @@ export class FromPoemIRIToTextgridInformationComponent implements OnChanges {
 
 //}
 
-performQuery() {
-    if(this.contentType === 'synopse') {
+  performQuery() {
+    if (this.contentType === 'synopse') {
       return this.http.get
       (
         globalSearchVariableService.API_URL +
@@ -78,47 +77,48 @@ performQuery() {
         '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fknora-base%23seqnum' +
         '&compop=EXISTS' +
         '&searchval=' +
-        /*'&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSameEditionAs' +
+        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSameEditionAs' +
         '&compop=EXISTS' +
-        '&searchval=' +*/
+        '&searchval=' +
         '&show_nrows=2000'
       )
         .map(
           (lambda: Response) => {
             const data = lambda.json();
             //console.log(data.subjects);
-            for(this.i = 0; this.i < data.subjects.length; this.i ++) {
+            for (this.i = 0; this.i < data.subjects.length; this.i++) {
               this.poemInformation[ this.i ] = [];
-              this.poemInformation[ this.i ][ 0 ]= data.subjects[ this.i ].value[ 7 ]; // poem title
-              this.poemInformation[ this.i ][ 1 ]= data.subjects[ this.i ].value[ 4 ]; // poem creation date
-              this.poemInformation[ this.i ][ 2 ]= data.subjects[ this.i ].value[ 6 ]; // poem text
-              this.poemInformation[ this.i ][ 3 ]= data.subjects[ this.i ].value[ 5 ]; // poem IRI
-              this.poemInformation[ this.i ][ 4 ]= data.subjects[ this.i ].value[ 3 ]; // convolute Title
-              this.poemInformation[ this.i ][ 5 ]= data.subjects[ this.i ].value[ 1 ]; // poem seqnum
+              this.poemInformation[ this.i ][ 0 ] = data.subjects[ this.i ].value[ 7 ]; // poem title
+              this.poemInformation[ this.i ][ 1 ] = data.subjects[ this.i ].value[ 4 ]; // poem creation date
+              this.poemInformation[ this.i ][ 2 ] = data.subjects[ this.i ].value[ 6 ]; // poem text
+              this.poemInformation[ this.i ][ 3 ] = data.subjects[ this.i ].value[ 5 ]; // poem IRI
+              this.poemInformation[ this.i ][ 4 ] = data.subjects[ this.i ].value[ 3 ]; // convolute Title
+              this.poemInformation[ this.i ][ 5 ] = data.subjects[ this.i ].value[ 1 ]; // poem seqnum
+              this.poemInformation[ this.i ][ 6 ] = data.subjects[ this.i ].value[ 8 ]; // hasSameEditionAs
               // TODO the following not hard coded but over triplestore requests
               if (this.poemInformation[ this.i ][ 4 ].includes('Notizbuch')) {
-                this.poemInformation[ this.i ][ 11 ] = '/notizbuecher/notizbuch-' + this.poemInformation[this.i][4].split(' ')[1];
+                this.poemInformation[ this.i ][ 11 ] = '/notizbuecher/notizbuch-' + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ];
               } else if (this.poemInformation[ this.i ][ 4 ].includes('manuskripte')) {
-                this.poemInformation[ this.i ][ 11 ] = '/manuskripte/manuskripte-' + this.poemInformation[this.i][4].split(' ')[1];
+                this.poemInformation[ this.i ][ 11 ] = '/manuskripte/manuskripte-' + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ];
               } else if (this.poemInformation[ this.i ][ 4 ].includes('Typoskript')) {
-                this.poemInformation[ this.i ][ 11 ] = '/typoskripte/typoskripte-' + this.poemInformation[this.i][4].split(' ')[1];
+                this.poemInformation[ this.i ][ 11 ] = '/typoskripte/typoskripte-' + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ];
               } else {
-                if (this.poemInformation[this.i][4] === 'GESICHT IM MITTAG 1950') {
-                  this.poemInformation[this.i][11] = '/drucke/gesicht-im-mittag';
-                } else if (this.poemInformation[this.i][4] === 'Die verwandelten Schiffe 1957') {
-                  this.poemInformation[this.i][11] = '/drucke/die-verwandelten-schiffe';
-                } else if (this.poemInformation[this.i][4] === 'GEDICHTE 1960') {
-                  this.poemInformation[this.i][11] = '/drucke/gedichte';
-                } else if (this.poemInformation[this.i][4] === 'FLUSSUFER 1963') {
-                  this.poemInformation[this.i][11] = '/drucke/flussufer';
-                } else if (this.poemInformation[this.i][4] === 'Reduktionen 1981') {
-                  this.poemInformation[this.i][11] = '/drucke/reduktionen';
-                } else if (this.poemInformation[this.i][4] === 'Hochdeutsche Gedichte 1985') {
-                  this.poemInformation[this.i][11] = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
-                } else if (this.poemInformation[this.i][4] === 'Alemannische Gedichte 1985') {
-                  this.poemInformation[this.i][11] = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
+                if (this.poemInformation[ this.i ][ 4 ] === 'GESICHT IM MITTAG 1950') {
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/gesicht-im-mittag';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'Die verwandelten Schiffe 1957') {
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/die-verwandelten-schiffe';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'GEDICHTE 1960') {
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/gedichte';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'FLUSSUFER 1963') {
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/flussufer';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'Reduktionen 1981') {
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/reduktionen';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'Hochdeutsche Gedichte 1985') {
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'Alemannische Gedichte 1985') {
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
                 } else {
-                  this.poemInformation[this.i][11] = '/drucke/verstreutes';
+                  this.poemInformation[ this.i ][ 11 ] = '/drucke/verstreutes';
                 }
               }
             }
@@ -139,19 +139,19 @@ performQuery() {
         encodeURIComponent(this.konvolutIRI) +
         '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasPoemTitle' +
         '&compop=!EQ' +
-        '&searchval=123455666'+
+        '&searchval=123455666' +
         '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasPoemCreationDate' +
         '&compop=!EQ' +
         '&searchval=GREGORIAN:2217-01-27' +
         '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasPoemText' +
         '&compop=!EQ' +
-        '&searchval=123455666'+
+        '&searchval=123455666' +
         '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasPoemIRI' +
         '&compop=!EQ' +
         '&searchval=123455666' +
         '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasConvoluteIRI' +
         '&compop=!EQ' +
-        '&searchval=123455666'+
+        '&searchval=123455666' +
         '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasConvoluteTitle' +
         '&compop=!EQ' +
         '&searchval=123455666' +
@@ -176,7 +176,7 @@ performQuery() {
           (lambda: Response) => {
             const data = lambda.json();
             //console.log(data.subjects[ 0 ]);
-            for(this.i = 0; this.i < data.subjects.length; this.i ++) {
+            for (this.i = 0; this.i < data.subjects.length; this.i++) {
               this.poemInformation[ this.i ] = [];
               this.poemInformation[ this.i ][ 0 ] = data.subjects[ this.i ].value[ 9 ];
               this.poemInformation[ this.i ][ 1 ] = data.subjects[ this.i ].value[ 6 ];
@@ -194,167 +194,167 @@ performQuery() {
         )
         .subscribe(response => this.responseArray = response);
     }
-}
+  }
 
   /*
-  getTitleAndDate(IRI: string, i: number) {
-    //console.log('get Title and Date' + IRI);
-    this.performQuery(IRI, i);
-  }
+   getTitleAndDate(IRI: string, i: number) {
+   //console.log('get Title and Date' + IRI);
+   this.performQuery(IRI, i);
+   }
 
-  performQuery(queryPart: string, i: number) {
-    return this.http.get
-    (
-      globalSearchVariableService.API_URL +
-      '/resources/' +
-      encodeURIComponent(queryPart)
-    )
-      .map(
-        (lambda: Response) => {
-          const data = lambda.json();
-          //console.log(data); */
+   performQuery(queryPart: string, i: number) {
+   return this.http.get
+   (
+   globalSearchVariableService.API_URL +
+   '/resources/' +
+   encodeURIComponent(queryPart)
+   )
+   .map(
+   (lambda: Response) => {
+   const data = lambda.json();
+   //console.log(data); */
 
-          /*
-          Fields in poemInformation
-          0: Poem title
-          1: Creation date of Poem
-          2: Edited text of this poem
-          3: Poem IRI
-          4: Same edition as poem: IRI
-          5: Array: Resource type of poem
-          6: Convolute link
-          7: Convolute title
-          8: seqnum of poem for sorting as in convolute
-          9: Array: synopse IRI
-          10: Has Date Index
-          11: Has alphabetic index
-          12: Has Synopsis Title
-           */
-/*
-          this.poemInformation[ i ][ 0 ] = data.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
-          this.poemInformation[ i ][ 1 ] = data.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1;
-          this.poemInformation[ i ][ 3 ] = queryPart;
-          this.poemInformation[ i ][ 5 ] = [];
-          this.poemInformation[ i ][ 9 ] = [];
-          this.poemInformation[ i ][ 8 ] = data.props['http://www.knora.org/ontology/knora-base#seqnum'].values[ 0 ];
-          if (this.router.url.split('/')[ 1 ] === 'synopsen' || this.router.url.split('/')[ 1 ] === 'suche') {
-            const sameEditionAs = data.props[ 'http://www.knora.org/ontology/kuno-raeber#hasSameEditionAs' ];
-            this.poemInformation[ i ][ 4 ] = sameEditionAs.values !== undefined;
-            this.poemInformation[ i ][ 5 ] = data.resdata[ 'restype_name' ].split('#')[ 1 ];
-            this.getConvoluteIriName(this.poemInformation[ i ][ 5 ], data, i);
-          } else {
-            for (let j = 0; j < data.incoming.length; j++ ) {
-              if (data.incoming[ j ].ext_res_id.pid === 'http://www.knora.org/ontology/work#isExpressedIn') {
-                this.poemInformation[ i ][ 9 ][ j ] = data.incoming[ j ].ext_res_id.id;
-              }
-            }
-          }
-          // console.log(data.resdata[ 'restype_name' ].split('#')[ 1 ]);
-          // console.log(data.resdata[ 'restype_name' ]);
-          // console.log(this.poemInformation[ i ][ 0 ]);
-          // console.log(this.poemInformation[ i ][ 1 ]);
-          this.performTextQuery(data.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ], i);
-          return data.resourcetypes;
-        }
-      )
-      .subscribe(response => this.responseArray = response);
-  }
+  /*
+   Fields in poemInformation
+   0: Poem title
+   1: Creation date of Poem
+   2: Edited text of this poem
+   3: Poem IRI
+   4: Same edition as poem: IRI
+   5: Array: Resource type of poem
+   6: Convolute link
+   7: Convolute title
+   8: seqnum of poem for sorting as in convolute
+   9: Array: synopse IRI
+   10: Has Date Index
+   11: Has alphabetic index
+   12: Has Synopsis Title
+   */
+  /*
+   this.poemInformation[ i ][ 0 ] = data.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
+   this.poemInformation[ i ][ 1 ] = data.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1;
+   this.poemInformation[ i ][ 3 ] = queryPart;
+   this.poemInformation[ i ][ 5 ] = [];
+   this.poemInformation[ i ][ 9 ] = [];
+   this.poemInformation[ i ][ 8 ] = data.props['http://www.knora.org/ontology/knora-base#seqnum'].values[ 0 ];
+   if (this.router.url.split('/')[ 1 ] === 'synopsen' || this.router.url.split('/')[ 1 ] === 'suche') {
+   const sameEditionAs = data.props[ 'http://www.knora.org/ontology/kuno-raeber#hasSameEditionAs' ];
+   this.poemInformation[ i ][ 4 ] = sameEditionAs.values !== undefined;
+   this.poemInformation[ i ][ 5 ] = data.resdata[ 'restype_name' ].split('#')[ 1 ];
+   this.getConvoluteIriName(this.poemInformation[ i ][ 5 ], data, i);
+   } else {
+   for (let j = 0; j < data.incoming.length; j++ ) {
+   if (data.incoming[ j ].ext_res_id.pid === 'http://www.knora.org/ontology/work#isExpressedIn') {
+   this.poemInformation[ i ][ 9 ][ j ] = data.incoming[ j ].ext_res_id.id;
+   }
+   }
+   }
+   // console.log(data.resdata[ 'restype_name' ].split('#')[ 1 ]);
+   // console.log(data.resdata[ 'restype_name' ]);
+   // console.log(this.poemInformation[ i ][ 0 ]);
+   // console.log(this.poemInformation[ i ][ 1 ]);
+   this.performTextQuery(data.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ], i);
+   return data.resourcetypes;
+   }
+   )
+   .subscribe(response => this.responseArray = response);
+   }
 
-  performTextQuery(IRI: string, i: number) {
-    //console.log('get Text: ' + IRI);
-    return this.http.get
-    (
-      globalSearchVariableService.API_URL +
-      '/resources/' +
-      encodeURIComponent(IRI)
-    )
-      .map(
-        (lambda: Response) => {
-          const data = lambda.json();
-          //console.log(data);
-          this.poemInformation[ i ][ 2 ] = data.props[ 'http://www.knora.org/ontology/text#hasContent' ].values[ 0 ].utf8str;
-          //console.log(this.poemInformation[i][2]);
-          this.countRequests += 1;
-          if (this.countRequests = this.poemIRIArray.length) {
-            this.sendPoemInformationBack.emit(this.poemInformation);
-          }
-          return data.resourcetypes;
-        }
-      )
-      .subscribe(response => this.responseArray = response);
+   performTextQuery(IRI: string, i: number) {
+   //console.log('get Text: ' + IRI);
+   return this.http.get
+   (
+   globalSearchVariableService.API_URL +
+   '/resources/' +
+   encodeURIComponent(IRI)
+   )
+   .map(
+   (lambda: Response) => {
+   const data = lambda.json();
+   //console.log(data);
+   this.poemInformation[ i ][ 2 ] = data.props[ 'http://www.knora.org/ontology/text#hasContent' ].values[ 0 ].utf8str;
+   //console.log(this.poemInformation[i][2]);
+   this.countRequests += 1;
+   if (this.countRequests = this.poemIRIArray.length) {
+   this.sendPoemInformationBack.emit(this.poemInformation);
+   }
+   return data.resourcetypes;
+   }
+   )
+   .subscribe(response => this.responseArray = response);
 
-  }
+   }
 
-  private getConvoluteIriName(res: string, data: any, i: number): void {
-    let convolute: string;
-    switch (res) {
-      case 'PoemNote':
-        //console.log(data);
-        this.getConvoluteTitleAlias(data.props[ 'http://www.knora.org/ontology/kuno-raeber#isInNotebook' ].values[ 0 ],
-          'notizbuecher', i);
-        break;
-      case 'HandwrittenPoem':
-        const manuscriptIri = data.props[ 'http://www.knora.org/ontology/text#isInManuscript' ].values[ 0 ];
-        this.getConvoluteIri(manuscriptIri, 'manuskripte', i);
-        break;
-      case 'PostCardPoem':
-        this.getConvoluteIri(data.props[ 'http://www.knora.org/ontology/text#isOnPostcard' ].values[ 0 ], 'karten', i);
-        break;
-      case 'TypewrittenPoem':
-        const typescriptIri = data.props[ 'http://www.knora.org/ontology/text#isInTypescript' ].values[ 0 ];
-        this.getConvoluteIri(typescriptIri, 'typoskripte', i);
-        break;
-      case 'PublicationPoem':
-        // console.log(data);
-        // FIXME: Remove next two lines if data problem is solved!
-        // this.poemInformation[ i ][ 6 ] = '';
-        // this.poemInformation[ i ][ 7 ] = '';
-        // FIXME: Data not available?
-        const publicationIri = (data.props[ 'http://www.knora.org/ontology/work#isPublishedIn' ].values === undefined ?
-        data.props[ 'http://www.knora.org/ontology/work#hasLastAuthorizedPublication' ].values[ 0 ] :
-        data.props[ 'http://www.knora.org/ontology/work#isPublishedIn' ].values[ 0 ]);
-        this.getConvoluteTitleAlias(publicationIri, 'drucke', i);
-    }
-  }
+   private getConvoluteIriName(res: string, data: any, i: number): void {
+   let convolute: string;
+   switch (res) {
+   case 'PoemNote':
+   //console.log(data);
+   this.getConvoluteTitleAlias(data.props[ 'http://www.knora.org/ontology/kuno-raeber#isInNotebook' ].values[ 0 ],
+   'notizbuecher', i);
+   break;
+   case 'HandwrittenPoem':
+   const manuscriptIri = data.props[ 'http://www.knora.org/ontology/text#isInManuscript' ].values[ 0 ];
+   this.getConvoluteIri(manuscriptIri, 'manuskripte', i);
+   break;
+   case 'PostCardPoem':
+   this.getConvoluteIri(data.props[ 'http://www.knora.org/ontology/text#isOnPostcard' ].values[ 0 ], 'karten', i);
+   break;
+   case 'TypewrittenPoem':
+   const typescriptIri = data.props[ 'http://www.knora.org/ontology/text#isInTypescript' ].values[ 0 ];
+   this.getConvoluteIri(typescriptIri, 'typoskripte', i);
+   break;
+   case 'PublicationPoem':
+   // console.log(data);
+   // FIXME: Remove next two lines if data problem is solved!
+   // this.poemInformation[ i ][ 6 ] = '';
+   // this.poemInformation[ i ][ 7 ] = '';
+   // FIXME: Data not available?
+   const publicationIri = (data.props[ 'http://www.knora.org/ontology/work#isPublishedIn' ].values === undefined ?
+   data.props[ 'http://www.knora.org/ontology/work#hasLastAuthorizedPublication' ].values[ 0 ] :
+   data.props[ 'http://www.knora.org/ontology/work#isPublishedIn' ].values[ 0 ]);
+   this.getConvoluteTitleAlias(publicationIri, 'drucke', i);
+   }
+   }
 
-  private getConvoluteIri(iri: string, convType: string, i: number): void {
-    let convoluteIri: string;
-    let convoluteLink: string;
+   private getConvoluteIri(iri: string, convType: string, i: number): void {
+   let convoluteIri: string;
+   let convoluteLink: string;
 
-    this.http.get(Config.API + 'resources/' + encodeURIComponent(iri)).map((res: any) => res.json())
-      .subscribe((res: any) => {
-        switch (convType) {
-          case 'manuskripte':
-            convoluteIri = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isPartOfManuscriptConvolute' ].values[ 0 ];
-            break;
-          case 'karten':
-            convoluteIri = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isPartOfPostcardConvolute' ].values[ 0 ];
-            break;
-          case 'typoskripte':
-            convoluteIri = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isPartOfTypescriptConvolute' ].values[ 0 ];
-            break;
-        }
-        this.getConvoluteTitleAlias(convoluteIri, convType, i);
-      });
-  }
+   this.http.get(Config.API + 'resources/' + encodeURIComponent(iri)).map((res: any) => res.json())
+   .subscribe((res: any) => {
+   switch (convType) {
+   case 'manuskripte':
+   convoluteIri = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isPartOfManuscriptConvolute' ].values[ 0 ];
+   break;
+   case 'karten':
+   convoluteIri = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isPartOfPostcardConvolute' ].values[ 0 ];
+   break;
+   case 'typoskripte':
+   convoluteIri = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isPartOfTypescriptConvolute' ].values[ 0 ];
+   break;
+   }
+   this.getConvoluteTitleAlias(convoluteIri, convType, i);
+   });
+   }
 
-  private getConvoluteTitleAlias(convoluteIri: string, convType: string, i: number): void {
-    this.http.get(Config.API + 'resources/' + encodeURIComponent(convoluteIri)).map((res: any) => res.json())
-      .subscribe((res: any) => {
-        // if (convType === 'drucke') {
-        //  this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/work#hasPublicationTitle' ].values[ 0 ][ 'utf8str' ];
-        //} else {
-          // this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ][ 'utf8str' ];
-        //}
-        console.log(res);
-        if (res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ] === undefined) {
-          this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/work#hasPublicationTitle' ].values[ 0 ][ 'utf8str' ];
-        } else {
-          this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ][ 'utf8str' ];
-        }
-        // TODO: Check links!
-        this.poemInformation[ i ][ 6 ] =
-          '/' + convType + '/' + res.props[ 'http://www.knora.org/ontology/text#hasAlias' ].values[ 0 ][ 'utf8str' ];
-      });
-  } */
+   private getConvoluteTitleAlias(convoluteIri: string, convType: string, i: number): void {
+   this.http.get(Config.API + 'resources/' + encodeURIComponent(convoluteIri)).map((res: any) => res.json())
+   .subscribe((res: any) => {
+   // if (convType === 'drucke') {
+   //  this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/work#hasPublicationTitle' ].values[ 0 ][ 'utf8str' ];
+   //} else {
+   // this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ][ 'utf8str' ];
+   //}
+   console.log(res);
+   if (res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ] === undefined) {
+   this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/work#hasPublicationTitle' ].values[ 0 ][ 'utf8str' ];
+   } else {
+   this.poemInformation[ i ][ 7 ] = res.props[ 'http://www.knora.org/ontology/text#hasConvoluteTitle' ].values[ 0 ][ 'utf8str' ];
+   }
+   // TODO: Check links!
+   this.poemInformation[ i ][ 6 ] =
+   '/' + convType + '/' + res.props[ 'http://www.knora.org/ontology/text#hasAlias' ].values[ 0 ][ 'utf8str' ];
+   });
+   } */
 }

--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -81,7 +81,7 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
    * @returns {boolean} Filtered
    */
   private static filterDuplicates(x: any): boolean {
-    return !x[ 4 ];
+    return x[ 6 ] !== '1';
   }
 
   /**
@@ -231,7 +231,10 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   filterPoems(unfiltered: Array<any>): Array<any> {
     if (unfiltered !== undefined) {
       return (this.filterFirstLastFlag ? TextgridComponent.filterFirstLast(unfiltered) : unfiltered)
-        .filter(x => this.filterDuplicatesFlag ? TextgridComponent.filterDuplicates(x) : x)
+        .filter(x => {
+          console.log('Flag: ' + x[ 4 ]);
+          return this.filterDuplicatesFlag ? TextgridComponent.filterDuplicates(x) : x
+        })
         .filter(x => this.filterNotebookFlag ? TextgridComponent.filterConvoluteTypes(x, 'Notizbuch') : x)
         .filter(x => this.filterManuscriptFlag ? TextgridComponent.filterConvoluteTypes(x, 'Manuskript') : x)
         .filter(x => this.filterTyposcriptFlag ? TextgridComponent.filterConvoluteTypes(x, 'Typoskript') : x);

--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -231,10 +231,7 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   filterPoems(unfiltered: Array<any>): Array<any> {
     if (unfiltered !== undefined) {
       return (this.filterFirstLastFlag ? TextgridComponent.filterFirstLast(unfiltered) : unfiltered)
-        .filter(x => {
-          console.log('Flag: ' + x[ 4 ]);
-          return this.filterDuplicatesFlag ? TextgridComponent.filterDuplicates(x) : x
-        })
+        .filter(x => this.filterDuplicatesFlag ? TextgridComponent.filterDuplicates(x) : x)
         .filter(x => this.filterNotebookFlag ? TextgridComponent.filterConvoluteTypes(x, 'Notizbuch') : x)
         .filter(x => this.filterManuscriptFlag ? TextgridComponent.filterConvoluteTypes(x, 'Manuskript') : x)
         .filter(x => this.filterTyposcriptFlag ? TextgridComponent.filterConvoluteTypes(x, 'Typoskript') : x);


### PR DESCRIPTION
Zu testen:
- Filtern von Duplikaten funktioniert.

Um Beispiele zu finden, ist es am einfachsten, auf der Original-Website nach Typoskripten zu suchen. Dann sollte eine Reihe von Duplikaten (graue Schrift) angezeigt werden, die für die Tests verwendet werden können.