### PR TITLE
NIE-141 rewrite fassung: signature

### DIFF
--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-signatur.component.html
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-signatur.component.html
@@ -1,4 +1,0 @@
-<span *ngFor="let s of signatures; let i = index">
-  <span>{{ s }}</span><span
-  *ngIf="i+1 < signatures.length">,</span>
-</span>

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-signatur.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-signatur.component.ts
@@ -9,30 +9,28 @@ import { globalSearchVariableService } from '../../suche/globalSearchVariablesSe
 @Component({
   moduleId: module.id,
   selector: 'rae-fassung-steckbrief-signatur',
-  templateUrl: 'fassung-steckbrief-signatur.component.html'
+  template: '<span>{{ signature }}</span>'
 })
 export class FassungSteckbriefSignaturComponent implements OnChanges {
 
-  @Input() carrierIRIs: Array<string>;
+  @Input() carrierIRI: string;
 
-  signatures: Array<string>;
+  signature: string;
 
   private sub: any;
 
-  constructor(private http: Http) {}
+  constructor(private http: Http) {
+  }
 
   ngOnChanges() {
-    this.signatures = [];
-    if (this.carrierIRIs) {
-      for (let i = 0; i < this.carrierIRIs.length; i++) {
-        this.sub = this.http.get(globalSearchVariableService.API_URL + '/resources/' +
-          encodeURIComponent(this.carrierIRIs[ i ]))
-          .map(result => result.json())
-          .subscribe(res => {
-            this.signatures.push(res.props[ 'http://www.knora.org/ontology/work#hasArchiveSignature' ].values[ 0 ].utf8str);
-            console.log(res.props[ 'http://www.knora.org/ontology/work#hasArchiveSignature' ].values[ 0 ].utf8str);
-          });
-      }
+    this.signature = '';
+    if (this.carrierIRI) {
+      this.sub = this.http.get(globalSearchVariableService.API_URL + '/resources/' +
+        encodeURIComponent(this.carrierIRI))
+        .map(result => result.json())
+        .subscribe(res => {
+          this.signature = res.props[ 'http://www.knora.org/ontology/work#hasArchiveSignature' ].values[ 0 ].utf8str;
+        });
     }
   }
 }

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
@@ -40,10 +40,10 @@
         <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Seite / Blatt:</span>
         <span  [innerHtml]="pageNumberDescription"></span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="carrierIRIs && carrierIRIs.length > 0" >
+    <li style="padding-bottom:5px;" *ngIf="carrierIRI" >
         <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Signatur:</span>
         <span >
-          <rae-fassung-steckbrief-signatur [carrierIRIs]="carrierIRIs"></rae-fassung-steckbrief-signatur>
+          <rae-fassung-steckbrief-signatur [carrierIRI]="carrierIRI"></rae-fassung-steckbrief-signatur>
         </span>
     </li>
     <li style="padding-bottom:5px;" *ngIf="textartMap[structure]" >

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
@@ -33,7 +33,7 @@ export class FassungSteckbriefComponent implements OnChanges {
   publishedIn: Array<string>;
   referencePoemIRIs: Array<string>;
 
-  carrierIRIs: Array<string>;
+  carrierIRI: string;
 
   schreibzeugMap = {
     'pencil': 'Bleistift',
@@ -191,35 +191,21 @@ export class FassungSteckbriefComponent implements OnChanges {
             // skip if there is no bezugstext
           }
 
-          this.carrierIRIs = [];
           try {
-            for (let i = 0; i <
-            res.props[ 'http://www.knora.org/ontology/kuno-raeber#isInNotebook' ].values.length; i++) {
-              this.carrierIRIs
-                .push(res.props[ 'http://www.knora.org/ontology/kuno-raeber#isInNotebook' ].values[ i ]);
-            }
+            this.carrierIRI = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isInNotebook' ].values[ 0 ];
           } catch (TypeError) {
             // skip if there is no notebook
           }
           try {
-            for (let i = 0; i <
-            res.props[ 'http://www.knora.org/ontology/text#isInManuscript' ].values.length; i++) {
-              this.carrierIRIs
-                .push(res.props[ 'http://www.knora.org/ontology/text#isInManuscript' ].values[ i ]);
-            }
-          } catch (TypeError) {
-            // skip if there is no manuscript
-          }
-          try {
-            for (let i = 0; i <
-            res.props[ 'http://www.knora.org/ontology/text#isInTypescript' ].values.length; i++) {
-              this.carrierIRIs
-                .push(res.props[ 'http://www.knora.org/ontology/text#isInTypescript' ].values[ i ]);
-            }
+            this.carrierIRI = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isInManuscript' ].values[ 0 ];
           } catch (TypeError) {
             // skip if there is no notebook
           }
-
+          try {
+            this.carrierIRI = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isInTypescript' ].values[ 0 ];
+          } catch (TypeError) {
+            // skip if there is no notebook
+          }
         });
     }
   }


### PR DESCRIPTION
The signature in the fassung informations should now only show one entry per poem. 
(It should be have behaved like this already before but probably some asynchronous parts messed with it.)

The signature component now expects only one carrier with one signature. 

Corresponds to https://nie-ine.myjetbrains.com/youtrack/issue/NIE-141