### PR TITLE
Fassung: Finalise migration to cachedPoems

### DIFF
--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -71,7 +71,7 @@
                       <br/>
 
                       <md-card
-                        *ngIf="convoluteType === 'PoemManuscriptConvolute' || convoluteType === 'PoemNotebook'"
+                        *ngIf="poemType === 'HandwrittenPoem' || poemType === 'PoemNote'"
                         style="padding-top:0;">
                         <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
                                         *ngIf="showDiplomaticTranscription">

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -69,8 +69,9 @@
                       </md-card>
                       <br/>
 
-                      <md-card *ngIf="konvolutType === 'PoemManuscriptConvolute' || konvolutType === 'PoemNotebook'"
-                               style="padding-top:0;">
+                      <md-card
+                        *ngIf="poemConvoluteType === 'PoemManuscriptConvolute' || poemConvoluteType === 'PoemNotebook'"
+                        style="padding-top:0;">
                         <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
                                         *ngIf="zeigeDiplomatisch">
                           <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch"

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -7,7 +7,8 @@
             <div id="rt-mainbody">
               <div class="component-content">
 
-                <span>Aktuelle Seite: {{konvolutTypeName}} > <a [routerLink]="konvolutLink">{{konvolutTitel}}</a></span>
+                <span>Aktuelle Seite: {{convoluteTypeGermanLabel}} > <a
+                  [routerLink]="convoluteLink">{{convoluteTitle}}</a></span>
 
                 <div id="rae-toolbar">
                   <rae-fassung-werkzeugleiste
@@ -16,16 +17,16 @@
                     [idOfNext]="nextPoem.split('###')[0]"
                     [(showRegister)]="show_register"
                     [(poemResizable)]="poem_resizable"
-                    (showEditedTextChange)="zeigeKonstituiert=true"
-                    (showTranscriptionChange)="zeigeDiplomatisch=false"></rae-fassung-werkzeugleiste>
+                    (showEditedTextChange)="showEditedText=true"
+                    (showTranscriptionChange)="showDiplomaticTranscription=false"></rae-fassung-werkzeugleiste>
                 </div>
 
                 <div id="k2Container" class="itemView">
 
                   <div class="itemTagsBlock" style='float:right'>
                     <ul class="itemTags">
-                      <a [routerLink]="['/synopsen/' + synopseIRI.split('/')[4]]" routerLinkActive="active"
-                         *ngIf="synopseIRI !== undefined">
+                      <a [routerLink]="['/synopsen/' + synopsisIri.split('/')[4]]" routerLinkActive="active"
+                         *ngIf="synopsisIri !== undefined">
                         Synopse
                       </a>
                     </ul>
@@ -33,7 +34,7 @@
 
                   <div class="itemHeader">
                     <!-- Date created -->
-                    <span class="itemDateCreated">{{ creationDate }}</span>
+                    <span class="itemDateCreated">{{ creationDateOfPoem }}</span>
                     <!-- Item title -->
                     <h2 class="itemTitle">{{ poemTitle }}</h2>
                   </div>
@@ -45,58 +46,59 @@
 
                       <md-card style="padding-top:0;">
                         <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
-                                        *ngIf="zeigeKonstituiert">
-                          <button md-button (click)="zeigeKonstituiert = !zeigeKonstituiert"
+                                        *ngIf="showEditedText">
+                          <button md-button (click)="showEditedText = !showEditedText"
                                   style="background-color:#eee;">
-                            <md-icon>{{zeigeKonstituiert ? 'expand_more' : 'expand_less'}}</md-icon>
-                            <span>Text {{zeigeKonstituiert ? 'verbergen' : 'anzeigen'}}</span>
+                            <md-icon>{{showEditedText ? 'expand_more' : 'expand_less'}}</md-icon>
+                            <span>Text {{showEditedText ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
                         </md-card-header>
                         <md-card-content style="padding-top:20px; padding-bottom:5px;"
-                          *ngIf="zeigeKonstituiert"
-                          [ngClass]="{'rae-fassung-resizable': poem_resizable, 'rae-fassung-nonresizable': !poem_resizable}">
+                                         *ngIf="showEditedText"
+                                         [ngClass]="{'rae-fassung-resizable': poem_resizable, 'rae-fassung-nonresizable': !poem_resizable}">
                           <section class="edtext edtext_hs">
                             <div [innerHTML]="editedPoemText"></div>
                           </section>
                         </md-card-content>
                         <md-card-footer>
-                          <button md-button (click)="zeigeKonstituiert = !zeigeKonstituiert"
+                          <button md-button (click)="showEditedText = !showEditedText"
                                   style="background-color:#eee;">
-                            <md-icon>{{zeigeKonstituiert ? 'expand_less' : 'expand_more'}}</md-icon>
-                            <span>Text {{zeigeKonstituiert ? 'verbergen' : 'anzeigen'}}</span>
+                            <md-icon>{{showEditedText ? 'expand_less' : 'expand_more'}}</md-icon>
+                            <span>Text {{showEditedText ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
                         </md-card-footer>
                       </md-card>
                       <br/>
 
                       <md-card
-                        *ngIf="poemConvoluteType === 'PoemManuscriptConvolute' || poemConvoluteType === 'PoemNotebook'"
+                        *ngIf="convoluteType === 'PoemManuscriptConvolute' || convoluteType === 'PoemNotebook'"
                         style="padding-top:0;">
                         <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
-                                        *ngIf="zeigeDiplomatisch">
-                          <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch"
+                                        *ngIf="showDiplomaticTranscription">
+                          <button md-button (click)="showDiplomaticTranscription = !showDiplomaticTranscription"
                                   style="background-color:#eee;">
-                            <md-icon>{{zeigeDiplomatisch ? 'expand_more' : 'expand_less'}}</md-icon>
-                            <span>Diplomatische Umschrift {{zeigeDiplomatisch ? 'verbergen' : 'anzeigen'}}</span>
+                            <md-icon>{{showDiplomaticTranscription ? 'expand_more' : 'expand_less'}}</md-icon>
+                            <span>Diplomatische Umschrift {{showDiplomaticTranscription ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
                         </md-card-header>
-                        <md-card-content *ngIf="zeigeDiplomatisch" style="padding-top:20px; padding-bottom:5px;">
+                        <md-card-content *ngIf="showDiplomaticTranscription"
+                                         style="padding-top:20px; padding-bottom:5px;">
                           <rae-fassung-diplomatisch [diplomaticIRIs]="diplomaticIRIs"
                                                     (pictureReduced)="show_register = true;"
                                                     (pictureIncreased)="show_register = false;">
                           </rae-fassung-diplomatisch>
                         </md-card-content>
                         <md-card-footer>
-                          <button md-button (click)="zeigeDiplomatisch = !zeigeDiplomatisch"
+                          <button md-button (click)="showDiplomaticTranscription = !showDiplomaticTranscription"
                                   style="background-color:#eee;">
-                            <md-icon>{{zeigeDiplomatisch ? 'expand_less' : 'expand_more'}}</md-icon>
-                            <span>Diplomatische Umschrift {{zeigeDiplomatisch ? 'verbergen' : 'anzeigen'}}</span>
+                            <md-icon>{{showDiplomaticTranscription ? 'expand_less' : 'expand_more'}}</md-icon>
+                            <span>Diplomatische Umschrift {{showDiplomaticTranscription ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
                         </md-card-footer>
                       </md-card>
                     </div>
                     <div style="margin-top:20px;">
-                      <rae-fassung-steckbrief [fassungIRI]="urlPrefix + poem_id" [konvolutIRI]="konvolutIRI">
+                      <rae-fassung-steckbrief [fassungIRI]="urlPrefix + poemShortIri" [konvolutIRI]="convoluteIri">
                       </rae-fassung-steckbrief>
                     </div>
                   </div>
@@ -106,9 +108,9 @@
                   <!-- Item tags -->
                   <div class="itemTagsBlock">
                     <span>Synopse:</span>
-                    <a [routerLink]="['/synopsen/' + synopseIRI.split('/')[4]]" routerLinkActive="active"
-                       *ngIf="synopseIRI !== undefined">
-                      {{workTitle}}
+                    <a [routerLink]="['/synopsen/' + synopsisIri.split('/')[4]]" routerLinkActive="active"
+                       *ngIf="synopsisIri !== undefined">
+                      {{synopsisTitle}}
                     </a>
                   </div>
                 </div>
@@ -117,7 +119,7 @@
                 <div class="itemRelated">
                   <rae-fassung-weitere
                     (goOtherFassung)="goToOtherFassung($event)"
-                    [synopsenTags]="otherWorkExpressions"></rae-fassung-weitere>
+                    [synopsenTags]="relatedPoems"></rae-fassung-weitere>
                 </div>
 
                 <div class="itemToolbar">
@@ -129,7 +131,7 @@
                       [titleOfPrev]="prevPoem.split('###')[1]"
                       [idOfNext]="nextPoem.split('###')[0]"
                       [titleOfNext]="nextPoem.split('###')[1]"></rae-fassung-blaettern>
-                    <span style='font-size:0.8em;'>Änderung: {{ modificationDate }}</span>
+                    <span style='font-size:0.8em;'>Änderung: {{ modificationDateOfPoem }}</span>
                   </ul>
                 </div>
               </div>
@@ -142,12 +144,12 @@
           <ngb-accordion #acc="ngbAccordion" activeIds="register,suche">
             <ngb-panel id="register" title="Register">
               <ng-template ngbPanelContent>
-                <rae-registerspalte [konvolutIRI]="konvolutIRI"
+                <rae-registerspalte [konvolutIRI]="convoluteIri"
                                     (goToOtherFassung)="goToOtherFassung($event)">
                 </rae-registerspalte>
               </ng-template>
             </ngb-panel>
-            <ngb-panel id="suche" title="Suche in {{konvolutTitle}}">
+            <ngb-panel id="suche" title="Suche in {{convoluteTitle}}">
               <ng-template ngbPanelContent>
                 <rae-konvolutsuche (suche)="searchInConvolute($event)"></rae-konvolutsuche>
               </ng-template>

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -1,6 +1,3 @@
-/**
- * Created by Sebastian Schüpbach (sebastian.schuepbach@unibas.ch) on 6/7/17.
- */
 import { AfterViewChecked, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Router } from '@angular/router';
@@ -143,7 +140,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
             this.convoluteTypeGermanLabel = 'DRUCK';
             break;
         }
-        this.getNeighbouringPoems(this.poemSeqnum);
+        this.getNeighbouringPoems();
       });
   }
 
@@ -153,8 +150,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .subscribe(res => this.editedPoemText = res.props[ 'http://www.knora.org/ontology/text#hasContent' ].values[ 0 ].utf8str);
   }
 
-  private getNeighbouringPoems(poemSeqnum: number) {
-    const searchParamsPrev = FassungComponent.createRequestForNeighbouringPoem(this.convoluteIri, (poemSeqnum - 1));
+  private getNeighbouringPoems() {
+    const searchParamsPrev = FassungComponent.createRequestForNeighbouringPoem(this.convoluteIri, (this.poemSeqnum - 1));
     this.http.get(searchParamsPrev)
       .map(result => result.json())
       .subscribe(res => {
@@ -162,7 +159,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
           this.prevPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.convoluteTitle);
         }
       });
-    const searchParamsNext = FassungComponent.createRequestForNeighbouringPoem(this.convoluteIri, (poemSeqnum + 1));
+    const searchParamsNext = FassungComponent.createRequestForNeighbouringPoem(this.convoluteIri, (this.poemSeqnum + 1));
     this.http.get(searchParamsNext)
       .map(result => result.json())
       .subscribe(res => {
@@ -193,10 +190,12 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       )
       .map(result => result.json())
       .subscribe(res => {
-        this.convoluteIri = res.subjects[ 0 ].value[ 1 ];
-        this.synopsisIri = res.subjects[ 0 ].value[ 3 ];
-        this.synopsisTitle = res.subjects[ 0 ].value[ 4 ];
-        this.getInformationOnRelatedPoems();
+        if (res.subjects[ 0 ] !== undefined) {
+          this.convoluteIri = res.subjects[ 0 ].value[ 1 ];
+          this.synopsisIri = res.subjects[ 0 ].value[ 3 ];
+          this.synopsisTitle = res.subjects[ 0 ].value[ 4 ];
+          this.getInformationOnRelatedPoems();
+        }
       });
   }
 

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -28,7 +28,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   urlPrefix: string = 'http://rdfh.ch/kuno-raeber/';
 
-  pageIRIs: Array<string>;
   diplomaticIRIs: Array<string>;
 
   poem_id: string;
@@ -61,7 +60,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   private static produceFassungsLink(titel: string, iri: string) {
     if (titel !== undefined && iri !== undefined) {
-      return titel.split('/')[0] + '---' + iri.split('raeber/')[1];
+      return titel.split('/')[ 0 ] + '---' + iri.split('raeber/')[ 1 ];
     } else {
       return 'Linkinformation has not arrived yet';
     }
@@ -70,16 +69,16 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   ngOnInit() {
     this.poem_resizable = true;
     this.show_register = true;
-    this.konvolutTitel = decodeURIComponent(this.router.url.split('/')[1]);
-    this.poem_id = this.router.url.split('/')[2].split('---')[1];
+    this.konvolutTitel = decodeURIComponent(this.router.url.split('/')[ 1 ]);
+    this.poem_id = this.router.url.split('/')[ 2 ].split('---')[ 1 ];
     this.updateView();
 
     if (this.konvolutTitel.includes('Notizbuch')) {
-      this.konvolutLink = '/notizbuecher/notizbuch-' + this.konvolutTitel.split(' ')[1];
+      this.konvolutLink = '/notizbuecher/notizbuch-' + this.konvolutTitel.split(' ')[ 1 ];
     } else if (this.konvolutTitel.includes('manuskripte')) {
-      this.konvolutLink = '/manuskripte/manuskripte-' + this.konvolutTitel.split(' ')[1];
+      this.konvolutLink = '/manuskripte/manuskripte-' + this.konvolutTitel.split(' ')[ 1 ];
     } else if (this.konvolutTitel.includes('Typoskript')) {
-      this.konvolutLink = '/typoskripte/typoskripte-' + this.konvolutTitel.split(' ')[1];
+      this.konvolutLink = '/typoskripte/typoskripte-' + this.konvolutTitel.split(' ')[ 1 ];
     } else {
       if (this.konvolutTitel === 'GESICHT IM MITTAG 1950') {
         this.konvolutLink = '/drucke/gesicht-im-mittag';
@@ -103,27 +102,28 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   updateView() {
     // TODO: Change when route definitions have been changed
+    console.log('IRI: ' + Config.API + 'resources/' + encodeURIComponent(this.urlPrefix + this.poem_id));
     this.http
       .get(Config.API + 'resources/' + encodeURIComponent(this.urlPrefix + this.poem_id))
       .map(result => result.json())
       .subscribe(res => {
         console.log(res);
+        this.poemConvoluteType = res.resinfo[ 'restype_id' ].split('#')[ 1 ];
         this.poemTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
         this.textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];
         this.getEditedPoemText(this.textEdition);
-        this.pageIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isOnPage' ].values;
-        this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
         this.poemSeqnum = res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ];
         this.creationDate = this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1);
         this.modificationDate = this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasModificationDate' ].values[ 0 ].utf8str);
-        this.poemConvoluteType = res.resdata[ 'restype_name' ].split('#')[ 1 ];
         switch (this.poemConvoluteType) {
           case 'PoemNote':
             this.convoluteProperty = 'http://www.knora.org/ontology/kuno-raeber#isInNotebook';
+            this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
             this.konvolutTypeName = 'Notizbuch';
             break;
           case 'HandwrittenPoem':
             this.convoluteProperty = 'http://www.knora.org/ontology/text#isInManuscript';
+            this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
             this.konvolutTypeName = 'Manuskript';
             break;
           case 'PostCardPoem':
@@ -148,7 +148,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .map(result => result.json())
       .subscribe(res => {
         for (const r of res.nodes) {
-          //console.log(r);
+          console.log('Konvolutyp (Model): ' + r[ 'resourceClassIri' ].split('#')[ 1 ]);
           if (r[ 'resourceClassIri' ].split('#')[ 1 ] === ('PoemNotebook' ||
               'PoemManuscriptConvolute' ||
               'PoemPostcardConvolute' ||

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -20,31 +20,29 @@ import { DateFormatService } from '../shared/utilities/date-format.service';
   styleUrls: [ 'fassung.component.css' ]
 })
 export class FassungComponent implements OnInit, AfterViewChecked {
-  creationDate: string;
-  modificationDate: string;
+  creationDateOfPoem: string;
+  modificationDateOfPoem: string;
 
-  zeigeKonstituiert: boolean = true;
-  zeigeDiplomatisch: boolean = false;
+  showEditedText: boolean = true;
+  showDiplomaticTranscription: boolean = false;
 
   urlPrefix: string = 'http://rdfh.ch/kuno-raeber/';
 
   diplomaticIRIs: Array<string>;
 
-  poem_id: string;
+  poemShortIri: string;
   poemTitle: string;
   poemSeqnum: number;
-  poemConvoluteType: string;
   editedPoemText: string;
-  textEdition: string;
-  konvolutType: string;
-  konvolutIRI: string;
-  konvolutTitel: string;
-  konvolutLink: string;
-  synopseIRI: string;
-  workTitle: string;
-  otherWorkExpressions: any[] = [];
+  convoluteType: string;
+  convoluteIri: string;
+  convoluteTitle: string;
+  convoluteLink: string;
+  synopsisIri: string;
+  synopsisTitle: string;
+  relatedPoems: any[] = [];
 
-  konvolutTypeName: string;
+  convoluteTypeGermanLabel: string;
 
   nextPoem: string = '';
   prevPoem: string = '';
@@ -58,9 +56,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
     } else {
       return 'Linkinformation has not arrived yet';
     }
-  }
-
-  constructor(private http: Http, private router: Router, private cdr: ChangeDetectorRef, private dfs: DateFormatService) {
   }
 
   private static createRequestForNeighbouringPoem(convoluteIRI: string, seqnumOfNeighbour: number) {
@@ -88,108 +83,68 @@ export class FassungComponent implements OnInit, AfterViewChecked {
     element.replace('/', '/*');
   }
 
+  constructor(private http: Http, private router: Router, private cdr: ChangeDetectorRef, private dfs: DateFormatService) {
+  }
+
   ngOnInit() {
     this.poem_resizable = true;
     this.show_register = true;
-    this.konvolutTitel = decodeURIComponent(this.router.url.split('/')[ 1 ]);
-    this.poem_id = this.router.url.split('/')[ 2 ].split('---')[ 1 ];
-    this.updateView();
-
-    if (this.konvolutTitel.includes('Notizbuch')) {
-      this.konvolutLink = '/notizbuecher/notizbuch-' + this.konvolutTitel.split(' ')[ 1 ];
-    } else if (this.konvolutTitel.includes('manuskripte')) {
-      this.konvolutLink = '/manuskripte/manuskripte-' + this.konvolutTitel.split(' ')[ 1 ];
-    } else if (this.konvolutTitel.includes('Typoskript')) {
-      this.konvolutLink = '/typoskripte/typoskripte-' + this.konvolutTitel.split(' ')[ 1 ];
-    } else {
-      if (this.konvolutTitel === 'GESICHT IM MITTAG 1950') {
-        this.konvolutLink = '/drucke/gesicht-im-mittag';
-      } else if (this.konvolutTitel === 'Die verwandelten Schiffe 1957') {
-        this.konvolutLink = '/drucke/die-verwandelten-schiffe';
-      } else if (this.konvolutTitel === 'GEDICHTE 1960') {
-        this.konvolutLink = '/drucke/gedichte';
-      } else if (this.konvolutTitel === 'FLUSSUFER 1963') {
-        this.konvolutLink = '/drucke/flussufer';
-      } else if (this.konvolutTitel === 'Reduktionen 1981') {
-        this.konvolutLink = '/drucke/reduktionen';
-      } else if (this.konvolutTitel === 'Hochdeutsche Gedichte 1985') {
-        this.konvolutLink = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
-      } else if (this.konvolutTitel === 'Alemannische Gedichte 1985') {
-        this.konvolutLink = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
-      } else {
-        this.konvolutLink = '/drucke/verstreutes';
-      }
-    }
-  }
-
-  updateView() {
-    this.http
-      .get(Config.API + 'resources/' + encodeURIComponent(this.urlPrefix + this.poem_id))
-      .map(result => result.json())
-      .subscribe(res => {
-        this.poemConvoluteType = res.resinfo[ 'restype_id' ].split('#')[ 1 ];
-        this.poemTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
-        this.textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];
-        this.getEditedPoemText(this.textEdition);
-        this.poemSeqnum = res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ];
-        this.creationDate = this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1);
-        this.modificationDate = this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasModificationDate' ].values[ 0 ].utf8str);
-        switch (this.poemConvoluteType) {
-          case 'PoemNote':
-            this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
-            this.konvolutTypeName = 'Notizbuch';
-            break;
-          case 'HandwrittenPoem':
-            // FIXME
-            this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
-            this.konvolutTypeName = 'Manuskript';
-            break;
-          case 'PostCardPoem':
-            // FIXME
-            this.konvolutTypeName = 'Manuskript';
-            break;
-          case 'TypewrittenPoem':
-            // FIXME
-            this.konvolutTypeName = 'Typoskript';
-            break;
-          case 'PublicationPoem':
-            this.konvolutTypeName = 'DRUCK';
-            break;
-        }
-        this.getNeighbouringPoems(this.poemSeqnum);
-      });
-
-    this.http
-      .get(globalSearchVariableService.API_URL +
-        globalSearchVariableService.extendedSearch +
-        'http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23Poem' +
-        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasPoemIRI' +
-        '&compop=EQ' +
-        '&searchval=' +
-        encodeURIComponent(this.urlPrefix + this.poem_id) +
-        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasConvoluteIRI' +
-        '&compop=EXISTS' +
-        '&searchval=' +
-        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSynopsisIRI' +
-        '&compop=EXISTS' +
-        '&searchval='
-      )
-      .map(result => result.json())
-      .subscribe(res => {
-        this.konvolutIRI = res.subjects[ 0 ].value[ 1 ];
-        this.synopseIRI = res.subjects[ 0 ].value[ 3 ];
-        this.getWork(this.synopseIRI);
-      });
-  }
-
-  goToOtherFassung(idOfFassung: string) {
-    const tempPoemId = idOfFassung.split('---')[ 1 ];
-    this.poem_id = tempPoemId !== undefined && !tempPoemId.includes('/') ? tempPoemId : this.poem_id;
-    this.updateView();
+    this.convoluteTitle = decodeURIComponent(this.router.url.split('/')[ 1 ]);
+    this.poemShortIri = this.router.url.split('/')[ 2 ].split('---')[ 1 ];
+    this.getDataFromDB();
+    this.buildLinkToRelatedConvolute();
   }
 
   ngAfterViewChecked() {
     this.cdr.detectChanges();
+  }
+
+  goToOtherFassung(idOfFassung: string) {
+    const tempPoemId = idOfFassung.split('---')[ 1 ];
+    this.poemShortIri = tempPoemId !== undefined && !tempPoemId.includes('/') ? tempPoemId : this.poemShortIri;
+    this.getDataFromDB();
+  }
+
+  private getDataFromDB() {
+    this.getBasicInformationOnCurrentPoem();
+    this.getConvoluteIriSynopsisIriAndRelatedPoems();
+  }
+
+  private getBasicInformationOnCurrentPoem() {
+    this.http
+      .get(Config.API + 'resources/' + encodeURIComponent(this.urlPrefix + this.poemShortIri))
+      .map(result => result.json())
+      .subscribe(res => {
+        this.convoluteType = res.resinfo[ 'restype_id' ].split('#')[ 1 ];
+        this.poemTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
+        const textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];
+        this.getEditedPoemText(textEdition);
+        this.poemSeqnum = res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ];
+        this.creationDateOfPoem =
+          this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1);
+        this.modificationDateOfPoem =
+          this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasModificationDate' ].values[ 0 ].utf8str);
+        switch (this.convoluteType) {
+          case 'PoemNote':
+            this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
+            this.convoluteTypeGermanLabel = 'Notizbuch';
+            break;
+          case 'HandwrittenPoem':
+            this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
+            this.convoluteTypeGermanLabel = 'Manuskript';
+            break;
+          case 'PostCardPoem':
+            this.convoluteTypeGermanLabel = 'Manuskript';
+            break;
+          case 'TypewrittenPoem':
+            this.convoluteTypeGermanLabel = 'Typoskript';
+            break;
+          case 'PublicationPoem':
+            this.convoluteTypeGermanLabel = 'DRUCK';
+            break;
+        }
+        this.getNeighbouringPoems(this.poemSeqnum);
+      });
   }
 
   private getEditedPoemText(editedTextIri: string) {
@@ -198,19 +153,61 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .subscribe(res => this.editedPoemText = res.props[ 'http://www.knora.org/ontology/text#hasContent' ].values[ 0 ].utf8str);
   }
 
-  private getWork(workIri: string) {
-    this.http.get(Config.API + 'resources/' + encodeURIComponent(workIri))
+  private getNeighbouringPoems(poemSeqnum: number) {
+    const searchParamsPrev = FassungComponent.createRequestForNeighbouringPoem(this.convoluteIri, (poemSeqnum - 1));
+    this.http.get(searchParamsPrev)
       .map(result => result.json())
       .subscribe(res => {
-        this.workTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
+        if (res.subjects[ 0 ] !== undefined) {
+          this.prevPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.convoluteTitle);
+        }
       });
+    const searchParamsNext = FassungComponent.createRequestForNeighbouringPoem(this.convoluteIri, (poemSeqnum + 1));
+    this.http.get(searchParamsNext)
+      .map(result => result.json())
+      .subscribe(res => {
+        if (res.subjects[ 0 ] !== undefined) {
+          this.nextPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.convoluteTitle);
+        }
+      });
+  }
+
+  private getConvoluteIriSynopsisIriAndRelatedPoems() {
+    this.http
+      .get(globalSearchVariableService.API_URL +
+        globalSearchVariableService.extendedSearch +
+        'http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23Poem' +
+        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasPoemIRI' +
+        '&compop=EQ' +
+        '&searchval=' +
+        encodeURIComponent(this.urlPrefix + this.poemShortIri) +
+        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasConvoluteIRI' +
+        '&compop=EXISTS' +
+        '&searchval=' +
+        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSynopsisIRI' +
+        '&compop=EXISTS' +
+        '&searchval=' +
+        '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSynopsisTitle' +
+        '&compop=EXISTS' +
+        '&searchval='
+      )
+      .map(result => result.json())
+      .subscribe(res => {
+        this.convoluteIri = res.subjects[ 0 ].value[ 1 ];
+        this.synopsisIri = res.subjects[ 0 ].value[ 3 ];
+        this.synopsisTitle = res.subjects[ 0 ].value[ 4 ];
+        this.getInformationOnRelatedPoems();
+      });
+  }
+
+  private getInformationOnRelatedPoems() {
     const request = globalSearchVariableService.API_URL +
       globalSearchVariableService.extendedSearch +
       'http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23Poem' +
       '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSynopsisIRI' +
       '&compop=EQ' +
       '&searchval=' +
-      encodeURIComponent(this.synopseIRI) +
+      encodeURIComponent(this.synopsisIri) +
       '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasPoemTitle' +
       '&compop=EXISTS' +
       '&searchval=' +
@@ -232,9 +229,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       '&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fknora-base%23seqnum' +
       '&compop=EXISTS' +
       '&searchval=' +
-      /*'&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber-gui%23hasSameEditionAs' +
-       '&compop=EXISTS' +
-       '&searchval=' +*/
       '&show_nrows=2000';
     return this.http.get(
       request
@@ -243,9 +237,9 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         (lambda: Response) => lambda.json()
       )
       .subscribe(response => {
-          this.otherWorkExpressions = [];
+        this.relatedPoems = [];
           for (let res of response.subjects) {
-            this.otherWorkExpressions.push('/' + res.value[ 3 ] + '/' +
+            this.relatedPoems.push('/' + res.value[ 3 ] + '/' +
               FassungComponent.produceFassungsLink(res.value[ 7 ], res.value[ 5 ]) +
               '###' + res.value[ 7 ]);
           }
@@ -253,23 +247,32 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       );
   }
 
-  private getNeighbouringPoems(poemSeqnum: number) {
-    const searchParamsPrev = FassungComponent.createRequestForNeighbouringPoem(this.konvolutIRI, (poemSeqnum - 1));
-    this.http.get(searchParamsPrev)
-      .map(result => result.json())
-      .subscribe(res => {
-        if (res.subjects[ 0 ] !== undefined) {
-          this.prevPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.konvolutTitel);
-        }
-      });
-    const searchParamsNext = FassungComponent.createRequestForNeighbouringPoem(this.konvolutIRI, (poemSeqnum + 1));
-    this.http.get(searchParamsNext)
-      .map(result => result.json())
-      .subscribe(res => {
-        if (res.subjects[ 0 ] !== undefined) {
-          this.nextPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.konvolutTitel);
-        }
-      });
+  private buildLinkToRelatedConvolute() {
+    if (this.convoluteTitle.includes('Notizbuch')) {
+      this.convoluteLink = '/notizbuecher/notizbuch-' + this.convoluteTitle.split(' ')[ 1 ];
+    } else if (this.convoluteTitle.includes('manuskripte')) {
+      this.convoluteLink = '/manuskripte/manuskripte-' + this.convoluteTitle.split(' ')[ 1 ];
+    } else if (this.convoluteTitle.includes('Typoskript')) {
+      this.convoluteLink = '/typoskripte/typoskripte-' + this.convoluteTitle.split(' ')[ 1 ];
+    } else {
+      if (this.convoluteTitle === 'GESICHT IM MITTAG 1950') {
+        this.convoluteLink = '/drucke/gesicht-im-mittag';
+      } else if (this.convoluteTitle === 'Die verwandelten Schiffe 1957') {
+        this.convoluteLink = '/drucke/die-verwandelten-schiffe';
+      } else if (this.convoluteTitle === 'GEDICHTE 1960') {
+        this.convoluteLink = '/drucke/gedichte';
+      } else if (this.convoluteTitle === 'FLUSSUFER 1963') {
+        this.convoluteLink = '/drucke/flussufer';
+      } else if (this.convoluteTitle === 'Reduktionen 1981') {
+        this.convoluteLink = '/drucke/reduktionen';
+      } else if (this.convoluteTitle === 'Hochdeutsche Gedichte 1985') {
+        this.convoluteLink = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
+      } else if (this.convoluteTitle === 'Alemannische Gedichte 1985') {
+        this.convoluteLink = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
+      } else {
+        this.convoluteLink = '/drucke/verstreutes';
+      }
+    }
   }
 
 }

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -32,9 +32,9 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   poemShortIri: string;
   poemTitle: string;
+  poemType: string;
   poemSeqnum: number;
   editedPoemText: string;
-  convoluteType: string;
   convoluteIri: string;
   convoluteTitle: string;
   convoluteLink: string;
@@ -115,7 +115,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .get(Config.API + 'resources/' + encodeURIComponent(this.urlPrefix + this.poemShortIri))
       .map(result => result.json())
       .subscribe(res => {
-        this.convoluteType = res.resinfo[ 'restype_id' ].split('#')[ 1 ];
+        this.poemType = res.resinfo[ 'restype_id' ].split('#')[ 1 ];
         this.poemTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
         const textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];
         this.getEditedPoemText(textEdition);
@@ -124,7 +124,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
           this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1);
         this.modificationDateOfPoem =
           this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasModificationDate' ].values[ 0 ].utf8str);
-        switch (this.convoluteType) {
+        switch (this.poemType) {
           case 'PoemNote':
             this.diplomaticIRIs = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasDiplomaticTranscription' ].values;
             this.convoluteTypeGermanLabel = 'Notizbuch';

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -69,18 +69,23 @@ export class FassungComponent implements OnInit, AfterViewChecked {
     return searchParams.toString();
   }
 
+  constructor(private http: Http,
+              private router: Router,
+              private cdr: ChangeDetectorRef,
+              private dfs: DateFormatService) {
+  }
+
   private static buildRouteTitleStringFromResultSet(resultSet: any, convoluteTitle: string) {
     const poemShortIRI = resultSet.subjects[ 0 ].value[ 3 ].split('/')[ 4 ];
     const poemTitle = resultSet.subjects[ 0 ].value[ 4 ];
-    return '/' + convoluteTitle + '/' + FassungComponent.escapeSlashesInRouteElement(poemTitle) +
+    return '/' + convoluteTitle + '/' + FassungComponent.removeSlashesInRouteElement(poemTitle) +
       '---' + poemShortIRI + '###' + poemTitle;
   }
 
-  private static escapeSlashesInRouteElement(element: string) {
-    element.replace('/', '/*');
-  }
-
-  constructor(private http: Http, private router: Router, private cdr: ChangeDetectorRef, private dfs: DateFormatService) {
+  private static removeSlashesInRouteElement(element: string) {
+    return element.includes('/') ?
+      element.replace('/', '') :
+      element;
   }
 
   ngOnInit() {

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -63,7 +63,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   constructor(private http: Http, private router: Router, private cdr: ChangeDetectorRef, private dfs: DateFormatService) {
   }
 
-  private static createRequestForNeighbourPoem(convoluteIRI: string, seqnumOfNeighbour: number) {
+  private static createRequestForNeighbouringPoem(convoluteIRI: string, seqnumOfNeighbour: number) {
     let searchParams = new ExtendedSearch();
     searchParams.filterByRestype = 'http://www.knora.org/ontology/kuno-raeber-gui#Poem';
     searchParams.property =
@@ -80,7 +80,12 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   private static buildRouteTitleStringFromResultSet(resultSet: any, convoluteTitle: string) {
     const poemShortIRI = resultSet.subjects[ 0 ].value[ 3 ].split('/')[ 4 ];
     const poemTitle = resultSet.subjects[ 0 ].value[ 4 ];
-    return '/' + convoluteTitle + '/' + poemTitle + '---' + poemShortIRI + '###' + poemTitle;
+    return '/' + convoluteTitle + '/' + FassungComponent.escapeSlashesInRouteElement(poemTitle) +
+      '---' + poemShortIRI + '###' + poemTitle;
+  }
+
+  private static escapeSlashesInRouteElement(element: string) {
+    element.replace('/', '/*');
   }
 
   ngOnInit() {
@@ -154,27 +159,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         this.getNeighbouringPoems(this.poemSeqnum);
       });
 
-    /*    this.http
-      .get(Config.API + 'graphdata/' + encodeURIComponent(this.urlPrefix + this.poem_id) + '?depth=2')
-      .map(result => result.json())
-      .subscribe(res => {
-        for (const r of res.nodes) {
-          if (r[ 'resourceClassIri' ].split('#')[ 1 ] === ('PoemNotebook' ||
-              'PoemManuscriptConvolute' ||
-              'PoemPostcardConvolute' ||
-              'PoemTypescriptConvolute' ||
-              'PrintedPoemBookPublication' ||
-              'PolyAuthorPublication')) {
-            //this.konvolutIRI = r[ 'resourceIri' ];
-            this.konvolutType = r[ 'resourceClassIri' ].split('#')[ 1 ];
-          }
-          if (r[ 'resourceClassIri' ].split('#')[ 1 ] === 'Work') {
-            this.synopseIRI = r[ 'resourceIri' ];
-            this.getWork(this.synopseIRI);
-          }
-        }
-     });*/
-
     this.http
       .get(globalSearchVariableService.API_URL +
         globalSearchVariableService.extendedSearch +
@@ -191,7 +175,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         '&searchval='
       )
       .map(result => result.json())
-      // FIXME: Problem!
       .subscribe(res => {
         this.konvolutIRI = res.subjects[ 0 ].value[ 1 ];
         this.synopseIRI = res.subjects[ 0 ].value[ 3 ];
@@ -271,19 +254,19 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   }
 
   private getNeighbouringPoems(poemSeqnum: number) {
-    const searchParamsPrev = FassungComponent.createRequestForNeighbourPoem(this.konvolutIRI, (poemSeqnum - 1));
+    const searchParamsPrev = FassungComponent.createRequestForNeighbouringPoem(this.konvolutIRI, (poemSeqnum - 1));
     this.http.get(searchParamsPrev)
       .map(result => result.json())
       .subscribe(res => {
-        if (res.subjects[ 0 ]) {
+        if (res.subjects[ 0 ] !== undefined) {
           this.prevPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.konvolutTitel);
         }
       });
-    const searchParamsNext = FassungComponent.createRequestForNeighbourPoem(this.konvolutIRI, (poemSeqnum + 1));
+    const searchParamsNext = FassungComponent.createRequestForNeighbouringPoem(this.konvolutIRI, (poemSeqnum + 1));
     this.http.get(searchParamsNext)
       .map(result => result.json())
       .subscribe(res => {
-        if (res.subjects[ 0 ]) {
+        if (res.subjects[ 0 ] !== undefined) {
           this.nextPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.konvolutTitel);
         }
       });


### PR DESCRIPTION
There were still some issues with the querying and navigation of poems in "Fassungsansicht". This PR should solve these problems, especially:
- No more errors when querying a typewritten or printed poem
- No more exceptions when opening a "Prosanotat" (this is just a security measure because "Prosanotate" are not in cachedPoems yet - hopefully this will change in the coming days)
- Navigation works as excepted even if the poem name contain a slash (`/ `). These chars must be escaped or removed. Unfortunately this will lead to another small issue: The poem title part of the shown URL is cropped or edited. However this won't affect the validity of the link because only the last part of the "poem" part of the route (i.e. the IRI) is actually used for querying.
- The diplomatic transcription is only shown if the the poem is of type `PoemNote` or `HandwrittenPoem` (the latter couldn't be checked because no manuscript poem is available at the moment)

What isn't solved yet:
- Navigation from a "Prosanotat" doesn't work as excepted. This is because the default way to obtain the convolute IRI - which is required to filter out predecessor and successor of the poem - does not succeed since the "Prosanotate" are not yet part of cachedPoems. Nonetheless it wouldn't make any sense to provide a "special" way to get this IRI because the "Prosanotate" will eventually also be available through cachedPoems. Right now there are two observed cases:
  - If you reach a "Prosanotat" by means of using the navigation buttons and the "Prosanotat" is the first element of the convolute, the navigation back to the second element works, but there is still a navigation button which seems to point to a (not existent) predecessor. However nothing happens if you click on this button
  - If you navigate directly to a "Prosanotat" by entering the URL no navigation buttons are shown at all at the bottom of the page