### PR TITLE
NIE-174, NIE-175, NIE-177: Änderungen in Synopsenansicht

### DIFF
--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -47,7 +47,7 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
 
   // Filter flags for synoptic view
   @Input() filterFirstLastFlag = false;
-  @Input() filterDuplicatesFlag = false;
+  @Input() filterDuplicatesFlag = true;
   @Input() filterNotebookFlag = false;
   @Input() filterManuscriptFlag = false;
   @Input() filterTyposcriptFlag = false;

--- a/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.html
+++ b/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.html
@@ -2,13 +2,12 @@
 
   <md-toolbar-row>
 
-    <button md-raised-button class="layoutbutton" (click)="showText = !showText; showTextChange.emit(showText);">
+    <button md-raised-button class="layoutbutton" (click)="toggleShowText()">
       {{showText ? 'Kein Text' : 'Text'}}
     </button>
 
-    <button md-raised-button class="layoutbutton" title="Spaltenanzahl"
-            (click)="columns = (columns % 3) + 1; cols.emit(columns)">{{(columns %
-      3) + 1}} Spalten
+    <button md-raised-button class="layoutbutton" title="Spaltenanzahl" (click)="rotateGridColumns()">
+      {{(columns % 3) + 1}} Spalten
     </button>
 
     <button md-raised-button class="layoutbutton" [disabled]="!rahmen || !showText || gridHeight >= 18"

--- a/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.ts
+++ b/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.ts
@@ -40,12 +40,29 @@ export class SynopseWerkzeugleisteComponent {
   }
 
   neuladen() {
-    this.rahmen = true;
+    if (!this.showText) {
+      this.toggleShowText();
+    }
+    if (!this.rahmen) {
+      this.toggleFrame();
+    }
     this.columns = 2;
     this.cols.emit(2);
     this.resetHeight.emit();
     if (this.firstLast) {
       this.setFirstLast();
+    }
+    if (!this.showDuplicates) {
+      this.toggleShowDuplicates();
+    }
+    if (!this.showNotebooks) {
+      this.toggleShowNotebooks();
+    }
+    if (!this.showManuscripts) {
+      this.toggleShowManuscripts();
+    }
+    if (!this.showTyposcripts) {
+      this.toggleShowTyposcripts();
     }
   }
 
@@ -55,6 +72,16 @@ export class SynopseWerkzeugleisteComponent {
 
   textVerkleinern() {
     this.verkleinereText.emit(null);
+  }
+
+  toggleShowText() {
+    this.showText = !this.showText;
+    this.showTextChange.emit(this.showText);
+  }
+
+  rotateGridColumns() {
+    this.columns = (this.columns % 3) + 1;
+    this.cols.emit(this.columns);
   }
 
   toggleFrame() {

--- a/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.ts
+++ b/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.ts
@@ -34,7 +34,7 @@ export class SynopseWerkzeugleisteComponent {
   showNotebooks: boolean = true;
   showManuscripts: boolean = true;
   showTyposcripts: boolean = true;
-  showDuplicates: boolean = true;
+  showDuplicates: boolean = false;
 
   constructor(public dialog: MdDialog) {
   }
@@ -52,7 +52,7 @@ export class SynopseWerkzeugleisteComponent {
     if (this.firstLast) {
       this.setFirstLast();
     }
-    if (!this.showDuplicates) {
+    if (this.showDuplicates) {
       this.toggleShowDuplicates();
     }
     if (!this.showNotebooks) {

--- a/src/client/app/synopse/synopse.component.html
+++ b/src/client/app/synopse/synopse.component.html
@@ -7,7 +7,7 @@
             <div class="rt-block">
               <div id="rt-mainbody">
                 <div class="component-content">
-                  <h1>Synopse ({{results}})</h1>
+                  <h1>Synopse: {{workTitle}} ({{results}})</h1>
                   <rae-synopse-werkzeugleiste #werkzeugleiste
                                               [(showText)]="showText"
                                               [gridHeight]="gridHeight"

--- a/src/client/app/synopse/synopse.component.ts
+++ b/src/client/app/synopse/synopse.component.ts
@@ -32,7 +32,7 @@ export class SynopseComponent implements OnInit {
   showNotebooks = true;
   showManuscripts = true;
   showTyposcripts = true;
-  showDuplicates = true;
+  showDuplicates = false;
 
   private sub: any;
 

--- a/src/client/app/synopse/synopse.component.ts
+++ b/src/client/app/synopse/synopse.component.ts
@@ -22,6 +22,7 @@ export class SynopseComponent implements OnInit {
   columns: string;
   gridHeight: number = 0;
   workIri: string;
+  workTitle: string;
   poemsIri: string[] = [];
 
   poems: Array<any>;
@@ -55,6 +56,7 @@ export class SynopseComponent implements OnInit {
       .map(response => response.json())
       .subscribe((res: any) => {
         this.poemsIri = res.props[ 'http://www.knora.org/ontology/work#isExpressedIn' ].values;
+        this.workTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
         this.results = this.poemsIri.length;
       });
   }


### PR DESCRIPTION
Zu testen:
- Reset setzt alle Darstellungsoptionen zurück ([NIE-177](https://nie-ine.myjetbrains.com/youtrack/issue/NIE-177), insbesondere
  - Duplikate
  - Text anzeigen / verstecken
  - Filter über Notizbücher, Manuskripte und Typoskripte
- Duplikate werden standardmässig nicht angezeigt ([NIE-175](https://nie-ine.myjetbrains.com/youtrack/issue/NIE-175))
- Titel der Synopse wird in Header angezeigt ([NIE-174](https://nie-ine.myjetbrains.com/youtrack/issue/NIE-174))