### PR TITLE
Poems in synopsis are sorted by seqnums as secondary argument

### DIFF
--- a/src/client/app/fassung/fassung-weitere/fassung-weitere.component.html
+++ b/src/client/app/fassung/fassung-weitere/fassung-weitere.component.html
@@ -1,11 +1,13 @@
-<h3>Weitere Fassungen</h3>
-<ul>
-  <ng-container *ngFor="let p of sortByDateAndSeqnum(synopsenTags);">
-  <li *ngIf="p !== undefined && !router.url.includes(p.split('###')[0].split('---')[1])">
-    <a [routerLink]="[p.split('###')[0]]" routerLinkActive="active" (click)="goToOtherFassung(p.split('###')[0])">
-      {{p.split('###')[1]}}
-    </a> <br/>
-    in : {{p.split('###')[0].split('/')[1]}}
-  </li>
-  </ng-container>
-</ul>
+<ng-container *ngIf="synopsenTags.length > 1">
+  <h3>Weitere Fassungen</h3>
+  <ul>
+    <ng-container *ngFor="let p of sortByDateAndSeqnum(synopsenTags);">
+      <li *ngIf="p !== undefined && !router.url.includes(p.split('###')[0].split('---')[1])">
+        <a [routerLink]="[p.split('###')[0]]" routerLinkActive="active" (click)="goToOtherFassung(p.split('###')[0])">
+          {{p.split('###')[1]}}
+        </a> <br/>
+        in : {{p.split('###')[0].split('/')[1]}}
+      </li>
+    </ng-container>
+  </ul>
+</ng-container>

--- a/src/client/app/fassung/fassung-weitere/fassung-weitere.component.html
+++ b/src/client/app/fassung/fassung-weitere/fassung-weitere.component.html
@@ -1,6 +1,6 @@
 <h3>Weitere Fassungen</h3>
 <ul>
-  <ng-container *ngFor="let p of synopsenTags;">
+  <ng-container *ngFor="let p of sortByDateAndSeqnum(synopsenTags);">
   <li *ngIf="p !== undefined && !router.url.includes(p.split('###')[0].split('---')[1])">
     <a [routerLink]="[p.split('###')[0]]" routerLinkActive="active" (click)="goToOtherFassung(p.split('###')[0])">
       {{p.split('###')[1]}}

--- a/src/client/app/fassung/fassung-weitere/fassung-weitere.component.ts
+++ b/src/client/app/fassung/fassung-weitere/fassung-weitere.component.ts
@@ -16,12 +16,51 @@ export class FassungWeitereComponent {
 
   @Output() goOtherFassung: EventEmitter<any> = new EventEmitter<any>();
 
+  private static getPoemDateFromPoemString(poemString: string) {
+    return poemString.split('###')[ 2 ];
+  }
+
+  private static getConvoluteTitleFromPoemString(poemString: string) {
+    return poemString.split('###')[ 0 ].split('/')[ 1 ];
+  }
+
+  private static getPoemSeqnumFromPoemString(poemString: string) {
+    return poemString.split('###')[ 3 ];
+  }
+
   constructor(private router: Router) {
   }
 
   goToOtherFassung(otherFassung: string) {
-    console.log('Go to other Fassung');
     this.goOtherFassung.emit(otherFassung);
   }
 
+  /**
+   * Orders an array by date (ascending) and seqnum (ascending)
+   * @param {Array<any>} unsorted Array to be sorted
+   * @returns {Array<any>} Sorted array
+   */
+  sortByDateAndSeqnum(unsorted: Array<string>): Array<string> {
+    return unsorted.sort((x, y) => {
+        if (FassungWeitereComponent.getPoemDateFromPoemString(x) > FassungWeitereComponent.getPoemDateFromPoemString(y)) {
+          return 1;
+        } else if (FassungWeitereComponent.getPoemDateFromPoemString(x) < FassungWeitereComponent.getPoemDateFromPoemString(y)) {
+          return -1;
+        } else {
+          if (FassungWeitereComponent.getConvoluteTitleFromPoemString(x) ===
+            FassungWeitereComponent.getConvoluteTitleFromPoemString(y)) {
+            if (FassungWeitereComponent.getPoemSeqnumFromPoemString(x) > FassungWeitereComponent.getPoemSeqnumFromPoemString(y)) {
+              return 1;
+            } else if (FassungWeitereComponent.getPoemSeqnumFromPoemString(x) < FassungWeitereComponent.getPoemSeqnumFromPoemString(y)) {
+              return -1;
+            } else {
+              return 0;
+            }
+          } else {
+            return 0;
+          }
+        }
+      }
+    );
+  }
 }

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -245,7 +245,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
           for (let res of response.subjects) {
             this.relatedPoems.push('/' + res.value[ 3 ] + '/' +
               FassungComponent.produceFassungsLink(res.value[ 7 ], res.value[ 5 ]) +
-              '###' + res.value[ 7 ]);
+              '###' + res.value[ 7 ] + '###' + res.value[ 4 ] + '###' + res.value[ 1 ]);
           }
         }
       );

--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -38,7 +38,6 @@
 
 
         <div class="catItemTagsBlock" *ngIf="contentType == 'synopse'">
-          <!-- Seqnum: {{p[5]}}<br/> -->
           <a [routerLink]="p[11]" routerLinkActive="active">{{ p[4] }}</a>
         </div>
 

--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -38,6 +38,7 @@
 
 
         <div class="catItemTagsBlock" *ngIf="contentType == 'synopse'">
+          <!-- Seqnum: {{p[5]}}<br/> -->
           <a [routerLink]="p[11]" routerLinkActive="active">{{ p[4] }}</a>
         </div>
 

--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -60,9 +60,9 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
    */
   private static sortByDate(unsorted: Array<any>): Array<any> {
     return unsorted.sort((x, y) => {
-        if (x[ 1 ] + String(1000000 + x[ 5 ]) > y[ 1 ] + String(1000000 + x[ 5 ])) {
+      if (x[ 1 ] > y[ 1 ]) {
           return 1;
-        } else if (x[ 1 ] + String(1000000 + x[ 5 ]) < x[ 1 ]+ String(1000000 + x[ 5 ])) {
+      } else if (x[ 1 ] < y[ 1 ]) {
           return -1;
         } else {
           if (x[ 4 ] === y[ 4 ]) {

--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -54,11 +54,10 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   @Input() konvolutView: boolean;
 
   /**
-   * Orders an array by date (ascending)
+   * Orders an array by date (ascending) and seqnum (ascending)
    * @param {Array<any>} unsorted Array to be sorted
    * @returns {Array<any>} Sorted array
    */
-  // TODO implement also three functions: first is sort by date, second by convolute title, third by seqnum
   private static sortByDate(unsorted: Array<any>): Array<any> {
     return unsorted.sort((x, y) => {
         if (x[ 1 ] + String(1000000 + x[ 5 ]) > y[ 1 ] + String(1000000 + x[ 5 ])) {
@@ -66,7 +65,17 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
         } else if (x[ 1 ] + String(1000000 + x[ 5 ]) < x[ 1 ]+ String(1000000 + x[ 5 ])) {
           return -1;
         } else {
-          return 0;
+          if (x[ 4 ] === y[ 4 ]) {
+            if (x[ 5 ] > y[ 5 ]) {
+              return 1;
+            } else if (x[ 5 ] < y[ 5 ]) {
+              return -1;
+            } else {
+              return 0;
+            }
+          } else {
+            return 0;
+          }
         }
       }
     );


### PR DESCRIPTION
# Änderungen
Im Moment werden die Fassungen in der Synopsenansicht nur nach Datum geordnet. D.h., die Ordnung von Fassungen mit gleichem Datum ist nicht determiniert. Neu wird daher sekundär auch nach Seqnum geordnet, sofern zwei Fassungen sich im selben Konvolut befinden.

# Zu testen
## 1)
Ordnung nach Datum (primär) und Seqnum (sekundär, nur falls im gleichen Konvolut). Damit die Seqnum der Fassungen angezeigt werden, hier Kommentar entfernen: https://github.com/nie-ine/raeber-website/blob/02752d6dda2a4b6c4c434c6fc6c2fe58134dcfaa/src/client/app/shared/textgrid/textgrid.component.html#L41 Vor Merging des PR die Zeile bitte löschen, sie erfüllt abgesehen von den aktuellen Tests keinen Zweck. Eine geeignete Synopse für das Testen ist `Mittag` (http://localhost:5555/synopsen/jUO2tbiXRNuTG5nbHt54kA).
## 2)
Dieselbe Sortierung soll auch bei `Weitere Fassungen` in der Fassungsansicht erscheinen. Hier zu testen: Sortierung ist analog zur Synopseansicht (**Vorsicht**: In `Weitere Fassungen` fehlt jeweils die aktuelle Fassung, d.h., es ist immer eine Fassung weniger in der Liste vorhanden als in der korrespondierenden Synopsenansicht)
## 3) (Bonus)
Titel `Weitere Fassungen` wird nicht angezeigt wenn keine weiteren Fassungen vorhanden sind. Beispiel: [Lozärn / 2 (A)](http://localhost:5555/Notizbuch%201979-82/Loz%C3%A4rn%20---IjH-5wr7SD24tdiaLLfa-A)