### PR TITLE
Fassungsansicht: Verschiedene kleinere Änderungen (NIE-157, NIE-159)

### DIFF
--- a/src/client/app/fassung/fassung-blaettern/fassung-blaettern.component.ts
+++ b/src/client/app/fassung/fassung-blaettern/fassung-blaettern.component.ts
@@ -2,7 +2,7 @@
  * Created by Reto Baumgartner (rfbaumgartner) on 05.07.17.
  */
 
-import { Component, Input, EventEmitter, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   moduleId: module.id,
@@ -19,12 +19,10 @@ export class FassungBlaetternComponent {
   @Output() goToOtherFassung: EventEmitter<any> = new EventEmitter<any>();
 
   goToNextFassung() {
-    console.log('Go to next Fassung');
     this.goToOtherFassung.emit(this.idOfNext);
   }
 
   goToPrevFassung() {
-    console.log('Go to prev Fassung');
     this.goToOtherFassung.emit(this.idOfPrev);
   }
 

--- a/src/client/app/fassung/fassung-werkzeugleiste/fassung-werkzeugleiste.component.html
+++ b/src/client/app/fassung/fassung-werkzeugleiste/fassung-werkzeugleiste.component.html
@@ -11,16 +11,10 @@
           [routerLink]="[idOfPrev]" (click)="goToPrevFassung()">
     <md-icon>navigate_before</md-icon>
   </button>
-  <button md-raised-button title="kein vorangehender Text" *ngIf="!idOfPrev" >
-    <md-icon class="button-without-link">navigate_before</md-icon>
-  </button>
 
   <button md-raised-button title="nächster Text" *ngIf="idOfNext"
           [routerLink]="[idOfNext]" (click)="goToNextFassung()">
     <md-icon>navigate_next</md-icon>
-  </button>
-  <button md-raised-button title="kein nächster Text" *ngIf="!idOfNext" >
-    <md-icon class="button-without-link">navigate_next</md-icon>
   </button>
 
   <button md-raised-button title="Hilfe" (click)="showHelp()">

--- a/src/client/app/fassung/fassung-werkzeugleiste/fassung-werkzeugleiste.component.ts
+++ b/src/client/app/fassung/fassung-werkzeugleiste/fassung-werkzeugleiste.component.ts
@@ -30,7 +30,7 @@ export class FassungWerkzeugleisteComponent {
   neuladen() {
     // TODO: Don't reload the whole window!
     // window.location.reload();
-    this.poemResizable = true;
+    this.poemResizable = false;
     this.showRegister = true;
     this.poemResizableChange.emit(this.poemResizable);
     this.showRegisterChange.emit(this.showRegister);

--- a/src/client/app/fassung/fassung.component.css
+++ b/src/client/app/fassung/fassung.component.css
@@ -2,7 +2,7 @@
 }
 
 .rae-fassung-nonresizable {
-  height: 280px;
+  height: 200px;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 }

--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -45,14 +45,6 @@
                     <div class="itemFullText">
 
                       <md-card style="padding-top:0;">
-                        <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
-                                        *ngIf="showEditedText">
-                          <button md-button (click)="showEditedText = !showEditedText"
-                                  style="background-color:#eee;">
-                            <md-icon>{{showEditedText ? 'expand_more' : 'expand_less'}}</md-icon>
-                            <span>Text {{showEditedText ? 'verbergen' : 'anzeigen'}}</span>
-                          </button>
-                        </md-card-header>
                         <md-card-content style="padding-top:20px; padding-bottom:5px;"
                                          *ngIf="showEditedText"
                                          [ngClass]="{'rae-fassung-resizable': poem_resizable, 'rae-fassung-nonresizable': !poem_resizable}">
@@ -62,7 +54,7 @@
                         </md-card-content>
                         <md-card-footer>
                           <button md-button (click)="showEditedText = !showEditedText"
-                                  style="background-color:#eee;">
+                                  style="background-color:#eee; font-size:12px;">
                             <md-icon>{{showEditedText ? 'expand_less' : 'expand_more'}}</md-icon>
                             <span>Text {{showEditedText ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
@@ -76,7 +68,7 @@
                         <md-card-header style="padding-left:0; padding-right:0; margin-left:-40px; margin-right:-24px;"
                                         *ngIf="showDiplomaticTranscription">
                           <button md-button (click)="showDiplomaticTranscription = !showDiplomaticTranscription"
-                                  style="background-color:#eee;">
+                                  style="background-color:#eee; font-size:12px;">
                             <md-icon>{{showDiplomaticTranscription ? 'expand_more' : 'expand_less'}}</md-icon>
                             <span>Diplomatische Umschrift {{showDiplomaticTranscription ? 'verbergen' : 'anzeigen'}}</span>
                           </button>
@@ -90,7 +82,7 @@
                         </md-card-content>
                         <md-card-footer>
                           <button md-button (click)="showDiplomaticTranscription = !showDiplomaticTranscription"
-                                  style="background-color:#eee;">
+                                  style="background-color:#eee; font-size:12px;">
                             <md-icon>{{showDiplomaticTranscription ? 'expand_less' : 'expand_more'}}</md-icon>
                             <span>Diplomatische Umschrift {{showDiplomaticTranscription ? 'verbergen' : 'anzeigen'}}</span>
                           </button>

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -162,6 +162,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .subscribe(res => {
         if (res.subjects[ 0 ] !== undefined) {
           this.prevPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.convoluteTitle);
+        } else {
+          this.prevPoem = '';
         }
       });
     const searchParamsNext = FassungComponent.createRequestForNeighbouringPoem(this.convoluteIri, (this.poemSeqnum + 1));
@@ -170,6 +172,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .subscribe(res => {
         if (res.subjects[ 0 ] !== undefined) {
           this.nextPoem = FassungComponent.buildRouteTitleStringFromResultSet(res, this.convoluteTitle);
+        } else {
+          this.nextPoem = '';
         }
       });
   }

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -89,7 +89,7 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   }
 
   ngOnInit() {
-    this.poem_resizable = true;
+    this.poem_resizable = false;
     this.show_register = true;
     this.convoluteTitle = decodeURIComponent(this.router.url.split('/')[ 1 ]);
     this.poemShortIri = this.router.url.split('/')[ 2 ].split('---')[ 1 ];


### PR DESCRIPTION
## NIE-157
- Oberer Button "Text verbergen" entfernt
- Kleinere Schrift für Buttons "Text verbergen" und "Diplomatische Umschrift verbergen" bzw. "...anzeigen"

## NIE-159
- Standardmässig ist nun eine fixe Höhe für edierten Text eingestellt
- Fixe Höhe ist verringert -> es soll bei einer üblichen Bildschirmauflösung und -höhe möglich sein, auch die weiteren Informationen zu lesen

## NIE-161
- Es wird kein Navigationsbutton in der Fassungsansicht angezeigt, wenn nicht zu einem vorherigen bzw. nachfolgenden Gedicht navigiert werden kann (d.h., wenn das Ende des Konvolutes erreicht worden ist). Zu prüfen: Sowohl in oberer als auch unterer Navigationsleiste