### PR TITLE
Kleine Layout-Verbesserungen diplomatische Umschrift

### DIFF
--- a/src/client/app/shared/image-frame/image-frame.component.html
+++ b/src/client/app/shared/image-frame/image-frame.component.html
@@ -18,7 +18,8 @@
 
   </md-toolbar>
 
-  <div [ngStyle]="{'height': height + px, 'width': width + px, 'overflow-y': overflow, 'resize': resize}" #picFrame>
+  <div [ngStyle]="{'height': height + px, 'width': width + px, 'overflow-y': overflow, 'resize': resize}"
+       style="margin-top:18px;" #picFrame>
     <!--  <img src="http://test-02.salsah.org/core/sendlocdata.php?res=212767&qtype=full&reduce={{ zoomfactor }}"
            class="rae-image_resizeable"> -->
     <img src="{{ pictureIdBase }}{{ width }},/0/default.jpg" class="rae-image_resizeable">

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -2792,6 +2792,11 @@ h4.ui-accordion-header {
   line-height: 15px;
 }
 
+h4.einfuegung {
+  font-weight: normal;
+  font-size: 100%;
+}
+
 .titelzeile_rechts {
   float: right;
   font-weight: bold;


### PR DESCRIPTION
NIE-167: Titel der diplomatischen Umschrift sollte sich nicht so stark abheben vom Rest des Textes
NIE-168: Mehr Abstand zwischen Digitalisat und Toolbar (Vergrössern, verkleinern etc.)