### PR TITLE
NIE-144: Konvolut: Steckbrief: Bilder

### DIFF
--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.html
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.html
@@ -1,4 +1,4 @@
 <span *ngIf="showThis" style="  color: #6e6e6e;">
-  <span class="emphase">Vorstufen:</span>
+  <span class="emphase">Bilder:</span>
   <a [href]="linkToPdf">Ganzes Buch (pdf)</a>
 </span>

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.html
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.html
@@ -1,0 +1,4 @@
+<span *ngIf="showThis" style="  color: #6e6e6e;">
+  <span class="emphase">Vorstufen:</span>
+  <a [href]="linkToPdf">Ganzes Buch (pdf)</a>
+</span>

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.html
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.html
@@ -1,4 +1,4 @@
 <span *ngIf="showThis" style="  color: #6e6e6e;">
   <span class="emphase">Bilder:</span>
-  <a [href]="linkToPdf">Ganzes Buch (pdf)</a>
+  <a [href]="linkToPdf" target="_blank">Ganzes Buch (pdf)</a>
 </span>

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief-bilder.component.ts
@@ -1,0 +1,31 @@
+/**
+ * Created by Reto Baumgartner (rfbaumgartner) on 30.10.17.
+ */
+import { Component, Input, OnChanges } from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'rae-konvolut-steckbrief-bilder',
+  templateUrl: 'konvolut-steckbrief-bilder.component.html'
+})
+export class KonvolutSteckbriefBilderComponent implements OnChanges {
+
+  @Input() konvolutId: string;
+  showThis: boolean = false;
+  linkToPdf: string;
+  assetBaseUrl: string = '/assets/pdf/notizbuecher/';
+
+  ngOnChanges() {
+    if (this.konvolutId && this.konvolutId === 'notizbuch-1979') {
+      this.linkToPdf = this.assetBaseUrl + 'A-5-g_01.pdf';
+      this.showThis = true;
+    } else if (this.konvolutId && this.konvolutId === 'notizbuch-1979-1982') {
+      this.linkToPdf = this.assetBaseUrl + 'A-5-h_01.pdf';
+      this.showThis = true;
+    } else if (this.konvolutId && this.konvolutId === 'notizbuch-1980-1988') {
+      this.linkToPdf = this.assetBaseUrl + 'A-5-h_02.pdf';
+      this.showThis = true;
+    }
+
+  }
+}

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.html
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.html
@@ -74,11 +74,8 @@
         <rae-konvolut-steckbrief-stufen [konvolutIRI]="earlierStagesIRIs"></rae-konvolut-steckbrief-stufen>
       </p>
 
-      <p *ngIf=false>
-        <span class="emphase">Bilder:</span>
-        <!-- TODO: hier Link zu PDF einfuegen und *ngIf anpassen-->
-        TODO
-      </p>
+      <rae-konvolut-steckbrief-bilder *ngIf="konvoluttyp == 'poem notebook'" [konvolutId]="id" >
+      </rae-konvolut-steckbrief-bilder>
 
       <p *ngIf="comment">
         <span class="emphase">Kommentar:</span>

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.html
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.html
@@ -35,6 +35,11 @@
         <span [innerHtml]="carrierDescription"></span>
       </p>
 
+      <p *ngIf="carrierCollectionDescription">
+        <span class="emphase">Textträger:</span>
+        <span [innerHtml]="carrierCollectionDescription"></span>
+      </p>
+
       <p *ngIf="convoluteSizeDescripton">
         <span class="emphase">Umfang:</span>
         <span [innerHtml]="convoluteSizeDescripton"></span>

--- a/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.ts
+++ b/src/client/app/konvolut/konvolut-steckbrief/konvolut-steckbrief.component.ts
@@ -29,6 +29,7 @@ export class KonvolutSteckbriefComponent implements OnChanges {
   printerDescription: string;
   convoluteDescription: string;
   carrierDescription: string;
+  carrierCollectionDescription: string;
   comment: string;
   archiveSignature: string;
   convoluteSizeDescripton: string;
@@ -80,6 +81,13 @@ export class KonvolutSteckbriefComponent implements OnChanges {
             this.carrierDescription = res.props[ 'http://www.knora.org/ontology/text#hasCarrierDescription' ].values[ 0 ].utf8str;
           } catch (TypeError) {
             this.carrierDescription = null;
+          }
+
+          try {
+            this.carrierCollectionDescription
+              = res.props[ 'http://www.knora.org/ontology/text#hasCarrierCollectionDescription' ].values[ 0 ].utf8str;
+          } catch (TypeError) {
+            this.carrierCollectionDescription = null;
           }
 
           try {

--- a/src/client/app/konvolut/konvolut.module.ts
+++ b/src/client/app/konvolut/konvolut.module.ts
@@ -36,6 +36,7 @@ import { GetKonvolutIRIComponent } from './get-konvolut-IRI/get-konvolut-IRI.com
 import { KonvolutTrefferleisteComponent } from './konvolut-trefferleiste/konvolut-trefferleiste.component';
 import { KonvolutSteckbriefMiniaturansichtComponent } from './konvolut-steckbrief/konvolut-steckbrief-miniaturansicht.component';
 import { KonvolutKommentarComponent } from './konvolut-kommentar/konvolut-kommentar.component';
+import { KonvolutSteckbriefBilderComponent } from './konvolut-steckbrief/konvolut-steckbrief-bilder.component';
 
 @NgModule({
   imports: [
@@ -62,6 +63,7 @@ import { KonvolutKommentarComponent } from './konvolut-kommentar/konvolut-kommen
   declarations: [
     KonvolutComponent,
     KonvolutKommentarComponent,
+    KonvolutSteckbriefBilderComponent,
     KonvolutSteckbriefComponent,
     KonvolutSteckbriefDatierungComponent,
     KonvolutSteckbriefMiniaturansichtComponent,

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.ts
@@ -42,7 +42,7 @@ export class DimplomatischerTextComponent implements OnInit, DoCheck, OnChanges 
   einfuegung_gestrElements = document.getElementsByClassName('einfuegung_gestr') as HTMLCollectionOf<HTMLElement>;
   einfuegung_gestr_typoElements = document.getElementsByClassName('einfuegung_gestr_typo') as HTMLCollectionOf<HTMLElement>;
   einfuegung_typoElements = document.getElementsByClassName('einfuegung_typo') as HTMLCollectionOf<HTMLElement>;
-  grundschichtElements = document.getElementsByClassName('grundschicht') as HTMLCollectionOf<HTMLElement>;
+  grundschichtElements = document.getElementsByClassName('schicht1') as HTMLCollectionOf<HTMLElement>;
   herausgeberElements = document.getElementsByClassName('herausgeber') as HTMLCollectionOf<HTMLElement>;
   markierungElements = document.getElementsByClassName('markierung') as HTMLCollectionOf<HTMLElement>;
   streichungElements = document.getElementsByClassName('streichung') as HTMLCollectionOf<HTMLElement>;


### PR DESCRIPTION
Die Bilder der Notizbücher, die ja schon vom Init-Skript in die Assets geladen werden, sind jetzt über den Steckbrief erreichbar.

Das Mapping kann ohne grosse Mühen ergänzt werden.

Testen: Auf einer Instanz mit geladenen Assets: die drei vorhandenen Notizbücher annavigieren und schauen, ob das Pdf erhältlich ist.