### PR TITLE
NIE-194: Standardmässig keine Scrollbar in angepasste Höhe in Textgrid

### DIFF
--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -28,7 +28,7 @@
 
       <md-card-content
         [ngClass]="{'rae-poem-card-content-grid': viewMode == 'grid', 'rae-poem-card-content-cols': viewMode == 'cols', 'hidden': !showText}"
-        [ngStyle]="{'height': rahmen ? 'calc(20em - '+poemTitle.offsetHeight+'px + '+gridTextHeight+'em)' :  poemText.offsetHeight+'px', 'overflow-y': rahmen ? 'auto' : 'visible'}">
+        [ngStyle]="{'height': rahmen ? 'calc(20em - '+poemTitle.offsetHeight+'px + '+gridTextHeight+'em)' :  'calc(15px + '+poemText.offsetHeight+'px)', 'overflow-y': rahmen ? 'auto' : 'auto'}">
         <div class="rae-poem" [innerHTML]="highlight(p[2],searchTermArray)" #poemText>
         </div>
       </md-card-content>


### PR DESCRIPTION
Zu testen:
- In Modus angepasste Höhe in Textgrid wird keine Scrollbar mehr angezeigt. Wird eine Textbox verkleinert, erscheint die Scrollbar