### PR TITLE
Nie 173 textgrid groessenanpassungen

### DIFF
--- a/src/client/app/shared/textgrid/textgrid.component.css
+++ b/src/client/app/shared/textgrid/textgrid.component.css
@@ -24,7 +24,7 @@
 }
 
 md-card-title a {
-  font-size: 80%;
+  font-size: 75%;
 }
 
 md-card-content {

--- a/src/client/app/shared/textgrid/textgrid.component.css
+++ b/src/client/app/shared/textgrid/textgrid.component.css
@@ -23,6 +23,14 @@
   width: 90%;
 }
 
+md-card-title a {
+  font-size: 80%;
+}
+
+md-card-content {
+  padding-left: 15px;
+}
+
 .rae-poem-card-content-cols {
   overflow-y: auto;
   overflow-x: auto;

--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -22,13 +22,13 @@
         </a>
         <a class="item" *ngIf="contentType == 'synopse' || contentType == 'suche'"
            [routerLink]="'/' + p[4] + produceFassungsLink(p[0],p[3])" routerLinkActive="active"
-           [innerHTML]="highlight(p[0],searchTermArray)" [ngStyle]="{ 'color': produceTitleCss(p[14]), 'font-size': '85%' }">
+           [innerHTML]="highlight(p[0],searchTermArray)" [ngStyle]="{ 'color': produceTitleCss(p[14])}">
         </a>
       </md-card-title>
 
       <md-card-content
         [ngClass]="{'rae-poem-card-content-grid': viewMode == 'grid', 'rae-poem-card-content-cols': viewMode == 'cols', 'hidden': !showText}"
-        [ngStyle]="{'height': rahmen ? 'calc(20em - '+poemTitle.offsetHeight+'px + '+gridTextHeight+'em)' :  'calc(15px + '+poemText.offsetHeight+'px)', 'overflow-y': rahmen ? 'auto' : 'auto'}">
+        [ngStyle]="{'height': rahmen ? 'calc(10em - '+poemTitle.offsetHeight+'px + '+gridTextHeight+'em)' :  'calc(15px + '+poemText.offsetHeight+'px)', 'overflow-y': rahmen ? 'auto' : 'auto'}">
         <div class="rae-poem" [innerHTML]="highlight(p[2],searchTermArray)" #poemText>
         </div>
       </md-card-content>

--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -33,8 +33,6 @@
         </div>
       </md-card-content>
 
-      <br/>
-
       <md-card-footer style="position: static;">
 
 


### PR DESCRIPTION
Zeilenanzahl sichtbar (durch padding-left)
Standardausgangshöhe für Text halbiert (nun 10em)
Gedichttitel verkleinert (nun auch überall gleich klein in Synopse, Konvolut und Konvolutsuche)
Leerzeile zwischen Text und Synopsenlink zur Abstandsverringerung entfernt.