### PR TITLE
Synopsentitel kleiner und weniger Abstände oberhalb Textgrid

### DIFF
--- a/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.css
+++ b/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.css
@@ -15,6 +15,10 @@ button {
   color: silver;
 }
 
+md-toolbar-row {
+  margin: -30px 0 0;
+}
+
 .layoutbutton {
   min-width: 90px;
   margin-left: 2px;

--- a/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.html
+++ b/src/client/app/synopse/synopse-werkzeugleiste/synopse-werkzeugleiste.component.html
@@ -1,7 +1,5 @@
 <md-toolbar>
 
-  <md-toolbar-row>
-
     <button md-raised-button class="layoutbutton" (click)="toggleShowText()">
       {{showText ? 'Kein Text' : 'Text'}}
     </button>
@@ -33,7 +31,6 @@
     <button md-raised-button title="Hilfe" (click)="showHelp()" style="margin-left:30px;">
       <md-icon>help</md-icon>
     </button>
-  </md-toolbar-row>
 
   <md-toolbar-row>
     <button md-raised-button class="layoutbutton" title="ErstLetzt" (click)="setFirstLast()">

--- a/src/client/app/synopse/synopse.component.html
+++ b/src/client/app/synopse/synopse.component.html
@@ -7,7 +7,7 @@
             <div class="rt-block">
               <div id="rt-mainbody">
                 <div class="component-content">
-                  <h1>Synopse: {{workTitle}} ({{results}})</h1>
+                  <h4 style="margin:5px">Synopse: {{workTitle}} ({{results}})</h4>
                   <rae-synopse-werkzeugleiste #werkzeugleiste
                                               [(showText)]="showText"
                                               [gridHeight]="gridHeight"


### PR DESCRIPTION
Synopsenüberschrift verkleinert (h4 statt h1)
Abstände zu und zwischen Toolbars (erste Zeile bekommt kein md-toolbar-row, erst die zweite)