### PR TITLE
Roby small fixes

### DIFF
--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -95,16 +95,16 @@
                   </div>
                 </div>
 
-                <div class="itemLinks">
-                  <!-- Item tags -->
-                  <div class="itemTagsBlock">
-                    <span>Synopse:</span>
+                <div style="margin: 16px 0;padding: 0;">
+                  <div style="float: right; display: inline-block;padding: 4px;border-bottom: 1px dotted #ccc;">
+                    <span style="font-weight: bold; color: #555;padding: 0 4px 0 0;">Synopse:</span>
                     <a [routerLink]="['/synopsen/' + synopsisIri.split('/')[4]]" routerLinkActive="active"
                        *ngIf="synopsisIri !== undefined">
                       {{synopsisTitle}}
                     </a>
                   </div>
                 </div>
+                <div style='clear:both'></div>
 
                 <!-- Related items by tag -->
                 <div class="itemRelated">

--- a/src/client/app/synopse/synopse.component.ts
+++ b/src/client/app/synopse/synopse.component.ts
@@ -57,7 +57,6 @@ export class SynopseComponent implements OnInit {
       .subscribe((res: any) => {
         this.poemsIri = res.props[ 'http://www.knora.org/ontology/work#isExpressedIn' ].values;
         this.workTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
-        this.results = this.poemsIri.length;
       });
   }
 
@@ -81,6 +80,7 @@ export class SynopseComponent implements OnInit {
 
   updatePoemInformation(poemInformation: Array<any>) {
     this.poems = poemInformation;
+    this.results = this.poems.length;
   }
 
   setFilterFirstLast() {


### PR DESCRIPTION
To test:
- the number (showed in the header) of poems in a synopse should be right now 
- in Fassung View, the second link to the Synopse (after the Fassung Steckbrief) shouldn't anymore overlap on the div for Blättern when no Weitere Fassung are presents.