### PR TITLE
NIE-200 Fassungsansicht für Tagebucheinträge

### DIFF
--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
@@ -211,6 +211,11 @@ export class FassungSteckbriefComponent implements OnChanges {
           } catch (TypeError) {
             // skip if there is no notebook
           }
+          try {
+            this.carrierIRI = res.props[ 'http://www.knora.org/ontology/kuno-raeber#isInDiary' ].values[ 0 ];
+          } catch (TypeError) {
+            // skip if there is no diary entry
+          }
         });
     }
   }

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -280,6 +280,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         this.convoluteLink = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
       } else if (this.convoluteTitle === 'Alemannische Gedichte 1985') {
         this.convoluteLink = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
+      } else if (this.convoluteTitle === 'Tagebuch') {
+        this.convoluteLink = '/material/tagebuecher';
       } else {
         this.convoluteLink = '/drucke/verstreutes';
       }

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -119,12 +119,14 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .get(Config.API + 'resources/' + encodeURIComponent(this.urlPrefix + this.poemShortIri))
       .map(result => result.json())
       .subscribe(res => {
+        console.log(res);
         this.poemType = res.resinfo[ 'restype_id' ].split('#')[ 1 ];
         this.poemTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
         const textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];
         this.getEditedPoemText(textEdition);
         this.poemSeqnum = res.props[ 'http://www.knora.org/ontology/knora-base#seqnum' ].values[ 0 ];
-        this.creationDateOfPoem =
+        this.creationDateOfPoem = this.poemType === 'DiaryEntry' ?
+          this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/text#hasEnteringDate' ].values[ 0 ].dateval1) :
           this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasCreationDate' ].values[ 0 ].dateval1);
         this.modificationDateOfPoem =
           this.dfs.germanLongDate(res.props[ 'http://www.knora.org/ontology/human#hasModificationDate' ].values[ 0 ].utf8str);

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -119,7 +119,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
       .get(Config.API + 'resources/' + encodeURIComponent(this.urlPrefix + this.poemShortIri))
       .map(result => result.json())
       .subscribe(res => {
-        console.log(res);
         this.poemType = res.resinfo[ 'restype_id' ].split('#')[ 1 ];
         this.poemTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
         const textEdition = res.props[ 'http://www.knora.org/ontology/kuno-raeber#hasEdition' ].values[ 0 ];


### PR DESCRIPTION
Zu testen:
- Fassungsansicht funktioniert für Tagebucheinträge: Navigation, Daten, Steckbriefeinträge, Text

Was nicht geht:
- Steckbrief: Letzter Druck (Feld fehlt in DB)
- Steckbrief: Besonderes (Feld fehlt in DB)
- Steckbrief: Seite / Blatt (Feld fehlt in DB)