### PR TITLE
Remove html: fix space issue

### DIFF
--- a/src/client/app/shared/fromPoemIRIToTextgridInformation/fromPoemIRIToTextgridInformation.component.ts
+++ b/src/client/app/shared/fromPoemIRIToTextgridInformation/fromPoemIRIToTextgridInformation.component.ts
@@ -117,6 +117,8 @@ export class FromPoemIRIToTextgridInformationComponent implements OnChanges {
                   this.poemInformation[ this.i ][ 11 ] = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
                 } else if (this.poemInformation[ this.i ][ 4 ] === 'Alemannische Gedichte 1985') {
                   this.poemInformation[ this.i ][ 11 ] = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'Tagebuch') {
+                  this.poemInformation[ this.i ][ 11 ] = '/material/tagebuecher';
                 } else {
                   this.poemInformation[ this.i ][ 11 ] = '/drucke/verstreutes';
                 }

--- a/src/client/app/shared/registerspalte/registerspalte.component.ts
+++ b/src/client/app/shared/registerspalte/registerspalte.component.ts
@@ -168,7 +168,10 @@ export class RegisterspalteComponent implements OnChanges {
 
   removeHtml(content: string) {
     if (content !== undefined) {
-      return content.replace(/<[^>]+>/g, '');
+      return content.replace(/<span class="zeile">[0-9]+\s*<\/span>/g, '')
+        .replace(/<br[^>a-zA-Z0-9]*>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .replace(/<[^>]+>/g, '');
     } else {
       return undefined;
       //console.log('no value yet');


### PR DESCRIPTION
Anstelle von Linebreaks gibt es jetzt einfache Spaces. Mehrfache Spaces werden gelöscht. Zeilenzahlen ebenfalls.

Ich habe noch einen kleinen Fix in den PR aufgenommen: Vom Textgrid gibt es jetzt korrekte Links zum Tagebuch.