### PR TITLE
CSS ausgelagert und float stabilisiert (clear)

### DIFF
--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.css
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.css
@@ -1,0 +1,17 @@
+ul {
+  list-style-type: none;
+  padding-left: 0;
+  margin-left: 0;
+}
+
+li {
+  padding-bottom: 5px;
+  clear: left;
+}
+
+.entryTitle {
+  float:left;
+  width:120px;
+  padding-left:10px;
+  font-weight:bold;
+}

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.html
@@ -1,87 +1,87 @@
 <div>
   <h3>Weitere Informationen</h3>
-  <ul style="list-style-type: none; padding-left: 0; margin-left:0;">
-    <li style="padding-bottom:5px;" *ngIf="specialDescription" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Besonderes:</span>
+  <ul>
+    <li *ngIf="specialDescription" >
+        <span class="entryTitle">Besonderes:</span>
         <span [innerHtml]="specialDescription"></span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="detailDescription" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Details:</span>
+    <li *ngIf="detailDescription" >
+        <span class="entryTitle">Details:</span>
         <span  [innerHtml]="detailDescription"></span>
     </li>
-    <!--<li style="padding-bottom: 5px;" *ngIf="convoluteTitle === 'Verstreutes' && publishedIn && publishedIn.length > 0">
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Zeitschrift:</span>
+    <!--<li *ngIf="convoluteTitle === 'Verstreutes' && publishedIn && publishedIn.length > 0">
+      <span class="entryTitle">Zeitschrift:</span>
       <span >
           <rae-fassung-steckbrief-konvolut [konvolutIRI]="publishedIn"></rae-fassung-steckbrief-konvolut>
         </span>
     </li>-->
-    <li style="padding-bottom: 5px;" *ngIf="!lastAuthorizedPublication && convoluteTitle === 'Verstreutes'">
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Letzter Druck:</span>
+    <li *ngIf="!lastAuthorizedPublication && convoluteTitle === 'Verstreutes'">
+      <span class="entryTitle">Letzter Druck:</span>
       <span>Verstreutes</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="lastAuthorizedPublication" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Letzter Druck:</span>
+    <li *ngIf="lastAuthorizedPublication" >
+        <span class="entryTitle">Letzter Druck:</span>
         <span >
           <rae-fassung-steckbrief-konvolut
             [konvolutIRI]="[lastAuthorizedPublication]"></rae-fassung-steckbrief-konvolut>
         </span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="publishingState === 'unpublished'" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Letzter Druck:</span>
+    <li *ngIf="publishingState === 'unpublished'" >
+        <span class="entryTitle">Letzter Druck:</span>
         <span >Unpubliziert</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="unauthorizedPublication && unauthorizedPublication.length > 0" >
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Nachdruck:</span>
+    <li *ngIf="unauthorizedPublication && unauthorizedPublication.length > 0" >
+      <span class="entryTitle">Nachdruck:</span>
       <span >
           <rae-fassung-steckbrief-konvolut [konvolutIRI]="unauthorizedPublication"></rae-fassung-steckbrief-konvolut>
         </span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="isFinalVersion" >
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Endfassung:</span>
+    <li *ngIf="isFinalVersion" >
+      <span class="entryTitle">Endfassung:</span>
       <span >ja</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="textartMap[structure]" >
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Textart:</span>
+    <li *ngIf="textartMap[structure]" >
+      <span class="entryTitle">Textart:</span>
       <span >{{ textartMap[structure] }}</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="carrierIRI" >
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Signatur:</span>
+    <li *ngIf="carrierIRI" >
+      <span class="entryTitle">Signatur:</span>
       <span >
           <rae-fassung-steckbrief-signatur [carrierIRI]="carrierIRI"></rae-fassung-steckbrief-signatur>
         </span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="pageNumberDescription" >
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Seite / Blatt:</span>
+    <li *ngIf="pageNumberDescription" >
+      <span class="entryTitle">Seite / Blatt:</span>
       <span  [innerHtml]="pageNumberDescription"></span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="publicationNumber" class="typeTextfield group2">
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Textnr.:</span>
+    <li *ngIf="publicationNumber" class="typeTextfield group2">
+      <span class="entryTitle">Textnr.:</span>
       <span  [innerHtml]="publicationNumber"></span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="nachlassPublicationDescription && nachlassPublicationDescription !== ' '" >
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Werke:</span>
+    <li *ngIf="nachlassPublicationDescription && nachlassPublicationDescription !== ' '" >
+      <span class="entryTitle">Werke:</span>
       <span  [innerHtml]="nachlassPublicationDescription"></span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="sameEditionAs && sameEditionAs.length > 0">
-      <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Identisch mit:</span>
+    <li *ngIf="sameEditionAs && sameEditionAs.length > 0">
+      <span class="entryTitle">Identisch mit:</span>
       <span >
           <rae-fassung-steckbrief-konvolut [konvolutIRI]="sameEditionAs"></rae-fassung-steckbrief-konvolut>
         </span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="hasStrophen" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Strophen:</span>
+    <li *ngIf="hasStrophen" >
+        <span class="entryTitle">Strophen:</span>
         <span >ja</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="isPartOfCycle" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Zyklus:</span>
+    <li *ngIf="isPartOfCycle" >
+        <span class="entryTitle">Zyklus:</span>
         <span >ja</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="isInDialect" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Mundart:</span>
+    <li *ngIf="isInDialect" >
+        <span class="entryTitle">Mundart:</span>
         <span >ja</span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="referencePoemIRI && referenceTitle" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Bezugstext:</span>
+    <li *ngIf="referencePoemIRI && referenceTitle" >
+        <span class="entryTitle">Bezugstext:</span>
         <span >
           <rae-fassung-steckbrief-fassung
             [fassungIRI]="referencePoemIRI"
@@ -90,8 +90,8 @@
           </rae-fassung-steckbrief-fassung>
         </span>
     </li>
-    <li style="padding-bottom:5px;" *ngIf="isWrittenWith" >
-        <span style="float:left; width:120px; padding-left:10px; font-weight:bold;">Schreibzeug:</span>
+    <li *ngIf="isWrittenWith" >
+        <span class="entryTitle">Schreibzeug:</span>
         <span >{{ schreibzeugMap[isWrittenWith] }}</span>
     </li>
   </ul>

--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief.component.ts
@@ -9,7 +9,8 @@ import { globalSearchVariableService } from '../../suche/globalSearchVariablesSe
 @Component({
   moduleId: module.id,
   selector: 'rae-fassung-steckbrief',
-  templateUrl: 'fassung-steckbrief.component.html'
+  templateUrl: 'fassung-steckbrief.component.html',
+  styleUrls: [ 'fassung-steckbrief.component.css' ]
 })
 export class FassungSteckbriefComponent implements OnChanges {
   @Input() fassungIRI: string;


### PR DESCRIPTION
Weitere Informationen:
Zeilen nun bereits auch ohne Einträge untereinander (clear). 
Damit bekommen die Zeilen nur noch etwas Abstand, wenn der Inhalt als Abfrageergebnis angezeigt wird. 

Bei der Gelegenheit gleich mal das css aufgeräumt.