### PR TITLE
kleine diplomatische fixes

### DIFF
--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.css
@@ -15,3 +15,7 @@ button.rae-image-small-button {
 .button-is-active {
   background-color: silver;
 }
+
+div.umschrift {
+  padding-left: 2em;
+}

--- a/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
+++ b/src/client/app/shared/diplomatischer-text/diplomatischer-text.component.html
@@ -1,5 +1,5 @@
 <div class="rae-diplomatic">
-  <menu>
+  <menu *ngIf="text !== ' '">
 
     <button md-raised-button
             [ngStyle]="{'color': farbeNeutral}"


### PR DESCRIPTION
(ausversehen auf dem falschen Branch)

Die Zeilennummern haben mehr Platz, bei NB79 U2 (Notiz 1) hat es keine Buttons, weil kein Text da ist.
Die erwähnte Klasse "transkription" gibt es in unseren Daten gar nicht.

Was ich nicht schaffen werde: Die Scrollbalken so zu setzen, dass alle Browser gehorchen. Da gibt es sehr viele Inkonsistenzen in der Anzeige zwischen Firefox und Chrome beispielsweise.