### PR TITLE
fix links to convolutes

### DIFF
--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -260,11 +260,13 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   private buildLinkToRelatedConvolute() {
     if (this.convoluteTitle.includes('Notizbuch')) {
-      this.convoluteLink = '/notizbuecher/notizbuch-' + this.convoluteTitle.split(' ')[ 1 ];
-    } else if (this.convoluteTitle.includes('manuskripte')) {
-      this.convoluteLink = '/manuskripte/manuskripte-' + this.convoluteTitle.split(' ')[ 1 ];
+      this.convoluteLink = '/notizbuecher/notizbuch-' + this.convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
+    } else if (this.convoluteTitle.includes('Manuskripte')) {
+      this.convoluteLink = '/manuskripte/manuskripte-' + this.convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
+    } else if (this.convoluteTitle.includes('Typoskripte 1979-spez')) {
+      this.convoluteLink = '/typoskripte/typoskripte-1979-spez';
     } else if (this.convoluteTitle.includes('Typoskript')) {
-      this.convoluteLink = '/typoskripte/typoskripte-' + this.convoluteTitle.split(' ')[ 1 ];
+      this.convoluteLink = '/typoskripte/typoskripte-' + this.convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
     } else {
       if (this.convoluteTitle === 'GESICHT IM MITTAG 1950') {
         this.convoluteLink = '/drucke/gesicht-im-mittag';
@@ -282,6 +284,8 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         this.convoluteLink = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
       } else if (this.convoluteTitle === 'Tagebuch') {
         this.convoluteLink = '/material/tagebuecher';
+      } else if (this.convoluteTitle === 'Karten 1984') {
+        this.convoluteLink = '/manuskripte/karten-1984';
       } else {
         this.convoluteLink = '/drucke/verstreutes';
       }

--- a/src/client/app/shared/fromPoemIRIToTextgridInformation/fromPoemIRIToTextgridInformation.component.ts
+++ b/src/client/app/shared/fromPoemIRIToTextgridInformation/fromPoemIRIToTextgridInformation.component.ts
@@ -97,11 +97,16 @@ export class FromPoemIRIToTextgridInformationComponent implements OnChanges {
               this.poemInformation[ this.i ][ 6 ] = data.subjects[ this.i ].value[ 8 ]; // hasSameEditionAs
               // TODO the following not hard coded but over triplestore requests
               if (this.poemInformation[ this.i ][ 4 ].includes('Notizbuch')) {
-                this.poemInformation[ this.i ][ 11 ] = '/notizbuecher/notizbuch-' + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ];
-              } else if (this.poemInformation[ this.i ][ 4 ].includes('manuskripte')) {
-                this.poemInformation[ this.i ][ 11 ] = '/manuskripte/manuskripte-' + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ];
+                this.poemInformation[ this.i ][ 11 ] = '/notizbuecher/notizbuch-'
+                  + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ].replace('-', '-19');
+              } else if (this.poemInformation[ this.i ][ 4 ].includes('Manuskripte')) {
+                this.poemInformation[ this.i ][ 11 ] = '/manuskripte/manuskripte-'
+                  + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ].replace('-', '-19');
+              } else if (this.poemInformation[ this.i ][ 4 ].includes('Typoskripte 1979-spez')) {
+                this.poemInformation[ this.i ][ 11 ] = '/typoskripte/typoskripte-1979-spez';
               } else if (this.poemInformation[ this.i ][ 4 ].includes('Typoskript')) {
-                this.poemInformation[ this.i ][ 11 ] = '/typoskripte/typoskripte-' + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ];
+                this.poemInformation[ this.i ][ 11 ] = '/typoskripte/typoskripte-'
+                  + this.poemInformation[ this.i ][ 4 ].split(' ')[ 1 ].replace('-', '-19');
               } else {
                 if (this.poemInformation[ this.i ][ 4 ] === 'GESICHT IM MITTAG 1950') {
                   this.poemInformation[ this.i ][ 11 ] = '/drucke/gesicht-im-mittag';
@@ -119,6 +124,8 @@ export class FromPoemIRIToTextgridInformationComponent implements OnChanges {
                   this.poemInformation[ this.i ][ 11 ] = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
                 } else if (this.poemInformation[ this.i ][ 4 ] === 'Tagebuch') {
                   this.poemInformation[ this.i ][ 11 ] = '/material/tagebuecher';
+                } else if (this.poemInformation[ this.i ][ 4 ] === 'Karten 1984') {
+                  this.poemInformation[ this.i ][ 11 ] = '/manuskripte/karten-1984';
                 } else {
                   this.poemInformation[ this.i ][ 11 ] = '/drucke/verstreutes';
                 }


### PR DESCRIPTION
Links to convolutes with year ranges should now work from the textgrid (Synopse) and from fassung (at the top).

Links to manuscripts are fixed.

Karten 1984 was added to the list.