### PR TITLE
Verschiedene Anpassungen (Teil 2)

### DIFF
--- a/src/client/app/fassung/fassung.component.html
+++ b/src/client/app/fassung/fassung.component.html
@@ -8,7 +8,7 @@
               <div class="component-content">
 
                 <span>Aktuelle Seite: {{convoluteTypeGermanLabel}} > <a
-                  [routerLink]="convoluteLink">{{convoluteTitle}}</a></span>
+                  [routerLink]="buildLinkToRelatedConvolute(convoluteTitle)">{{convoluteTitle}}</a></span>
 
                 <div id="rae-toolbar">
                   <rae-fassung-werkzeugleiste

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, OnChanges, OnInit } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import 'rxjs/add/operator/catch';
@@ -45,6 +45,104 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
   poem_resizable: boolean;
   show_register: boolean;
+
+  private static produceFassungsLink(titel: string, iri: string) {
+    if (titel !== undefined && iri !== undefined) {
+      return titel.split('/')[ 0 ] + '---' + iri.split('raeber/')[ 1 ];
+    } else {
+      return 'Linkinformation has not arrived yet';
+    }
+  }
+
+  private static createRequestForNeighbouringPoem(convoluteIRI: string, seqnumOfNeighbour: number) {
+    let searchParams = new ExtendedSearch();
+    searchParams.filterByRestype = 'http://www.knora.org/ontology/kuno-raeber-gui#Poem';
+    searchParams.property =
+      new KnoraProperty('http://www.knora.org/ontology/kuno-raeber-gui#hasConvoluteIRI', 'EQ', convoluteIRI);
+    searchParams.property =
+      new KnoraProperty('http://www.knora.org/ontology/knora-base#seqnum', 'EQ', (seqnumOfNeighbour).toString());
+    searchParams.property =
+      new KnoraProperty('http://www.knora.org/ontology/kuno-raeber-gui#hasPoemIRI', 'EXISTS', '');
+    searchParams.property =
+      new KnoraProperty('http://www.knora.org/ontology/kuno-raeber-gui#hasPoemTitle', 'EXISTS', '');
+    return searchParams.toString();
+  }
+
+  private static buildRouteTitleStringFromResultSet(resultSet: any, convoluteTitle: string) {
+    const poemShortIRI = resultSet.subjects[ 0 ].value[ 3 ].split('/')[ 4 ];
+    const poemTitle = resultSet.subjects[ 0 ].value[ 4 ];
+    return '/' + convoluteTitle + '/' + FassungComponent.removeSlashesInRouteElement(poemTitle) +
+      '---' + poemShortIRI + '###' + poemTitle;
+  }
+
+  private static removeSlashesInRouteElement(element: string) {
+    return element.includes('/') ?
+      element.replace(/\//g, '') :
+      element;
+  }
+
+  goToConvoluteview(searchTerm: string, page: string, convolutURl: string) {
+    this.router.navigateByUrl(
+      convolutURl +
+      '?wort=' +
+      searchTerm +
+      '&page=' + page);
+  }
+
+  constructor(private http: Http,
+              private route: ActivatedRoute,
+              private cdr: ChangeDetectorRef,
+              private dfs: DateFormatService,
+              private router: Router) {
+    route.params.subscribe(p => {
+      this.convoluteTitle = p.konvolut;
+      this.poemShortIri = p.fassung.split('---')[ 1 ];
+    });
+  }
+
+  ngOnInit() {
+    this.poem_resizable = false;
+    this.show_register = true;
+    this.getDataFromDB();
+  }
+
+  ngAfterViewChecked() {
+    this.cdr.detectChanges();
+  }
+
+  buildLinkToRelatedConvolute(convoluteTitle: string): string {
+    if (convoluteTitle.includes('Notizbuch')) {
+      return '/notizbuecher/notizbuch-' + convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
+    } else if (convoluteTitle.includes('Manuskripte')) {
+      return '/manuskripte/manuskripte-' + convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
+    } else if (convoluteTitle.includes('Typoskripte 1979-spez')) {
+      return '/typoskripte/typoskripte-1979-spez';
+    } else if (convoluteTitle.includes('Typoskript')) {
+      return '/typoskripte/typoskripte-' + convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
+    } else {
+      if (convoluteTitle === 'GESICHT IM MITTAG 1950') {
+        return '/drucke/gesicht-im-mittag';
+      } else if (convoluteTitle === 'Die verwandelten Schiffe 1957') {
+        return '/drucke/die-verwandelten-schiffe';
+      } else if (convoluteTitle === 'GEDICHTE 1960') {
+        return '/drucke/gedichte';
+      } else if (convoluteTitle === 'FLUSSUFER 1963') {
+        return '/drucke/flussufer';
+      } else if (convoluteTitle === 'Reduktionen 1981') {
+        return '/drucke/reduktionen';
+      } else if (convoluteTitle === 'Hochdeutsche Gedichte 1985') {
+        return '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
+      } else if (convoluteTitle === 'Alemannische Gedichte 1985') {
+        return '/drucke/abgewandt-zugewandt-alemannische-gedichte';
+      } else if (convoluteTitle === 'Tagebuch') {
+        return '/material/tagebuecher';
+      } else if (convoluteTitle === 'Karten 1984') {
+        return '/manuskripte/karten-1984';
+      } else {
+        return '/drucke/verstreutes';
+      }
+    }
+  }
 
   searchInConvolute(searchTerm: any) {
     console.log(searchTerm);
@@ -93,70 +191,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
 
 
     }
-  }
-  goToConvoluteview(searchTerm: string, page: string, convolutURl: string) {
-    this.router.navigateByUrl(
-      convolutURl +
-      '?wort=' +
-      searchTerm +
-      '&page=' + page);
-  }
-
-  private static produceFassungsLink(titel: string, iri: string) {
-    if (titel !== undefined && iri !== undefined) {
-      return titel.split('/')[ 0 ] + '---' + iri.split('raeber/')[ 1 ];
-    } else {
-      return 'Linkinformation has not arrived yet';
-    }
-  }
-
-  private static createRequestForNeighbouringPoem(convoluteIRI: string, seqnumOfNeighbour: number) {
-    let searchParams = new ExtendedSearch();
-    searchParams.filterByRestype = 'http://www.knora.org/ontology/kuno-raeber-gui#Poem';
-    searchParams.property =
-      new KnoraProperty('http://www.knora.org/ontology/kuno-raeber-gui#hasConvoluteIRI', 'EQ', convoluteIRI);
-    searchParams.property =
-      new KnoraProperty('http://www.knora.org/ontology/knora-base#seqnum', 'EQ', (seqnumOfNeighbour).toString());
-    searchParams.property =
-      new KnoraProperty('http://www.knora.org/ontology/kuno-raeber-gui#hasPoemIRI', 'EXISTS', '');
-    searchParams.property =
-      new KnoraProperty('http://www.knora.org/ontology/kuno-raeber-gui#hasPoemTitle', 'EXISTS', '');
-    return searchParams.toString();
-  }
-
-  private static buildRouteTitleStringFromResultSet(resultSet: any, convoluteTitle: string) {
-    const poemShortIRI = resultSet.subjects[ 0 ].value[ 3 ].split('/')[ 4 ];
-    const poemTitle = resultSet.subjects[ 0 ].value[ 4 ];
-    return '/' + convoluteTitle + '/' + FassungComponent.removeSlashesInRouteElement(poemTitle) +
-      '---' + poemShortIRI + '###' + poemTitle;
-  }
-
-  private static removeSlashesInRouteElement(element: string) {
-    return element.includes('/') ?
-      element.replace(/\//g, '') :
-      element;
-  }
-
-  constructor(private http: Http,
-              private route: ActivatedRoute,
-              private cdr: ChangeDetectorRef,
-              private dfs: DateFormatService,
-              private router: Router) {
-    route.params.subscribe(p => {
-      this.convoluteTitle = p.konvolut;
-      this.poemShortIri = p.fassung.split('---')[ 1 ];
-    });
-  }
-
-  ngOnInit() {
-    this.poem_resizable = false;
-    this.show_register = true;
-    this.getDataFromDB();
-    this.buildLinkToRelatedConvolute();
-  }
-
-  ngAfterViewChecked() {
-    this.cdr.detectChanges();
   }
 
   goToOtherFassung(idOfFassung: string) {
@@ -318,40 +352,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
           }
         }
       );
-  }
-
-  private buildLinkToRelatedConvolute() {
-    if (this.convoluteTitle.includes('Notizbuch')) {
-      this.convoluteLink = '/notizbuecher/notizbuch-' + this.convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
-    } else if (this.convoluteTitle.includes('Manuskripte')) {
-      this.convoluteLink = '/manuskripte/manuskripte-' + this.convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
-    } else if (this.convoluteTitle.includes('Typoskripte 1979-spez')) {
-      this.convoluteLink = '/typoskripte/typoskripte-1979-spez';
-    } else if (this.convoluteTitle.includes('Typoskript')) {
-      this.convoluteLink = '/typoskripte/typoskripte-' + this.convoluteTitle.split(' ')[ 1 ].replace('-', '-19');
-    } else {
-      if (this.convoluteTitle === 'GESICHT IM MITTAG 1950') {
-        this.convoluteLink = '/drucke/gesicht-im-mittag';
-      } else if (this.convoluteTitle === 'Die verwandelten Schiffe 1957') {
-        this.convoluteLink = '/drucke/die-verwandelten-schiffe';
-      } else if (this.convoluteTitle === 'GEDICHTE 1960') {
-        this.convoluteLink = '/drucke/gedichte';
-      } else if (this.convoluteTitle === 'FLUSSUFER 1963') {
-        this.convoluteLink = '/drucke/flussufer';
-      } else if (this.convoluteTitle === 'Reduktionen 1981') {
-        this.convoluteLink = '/drucke/reduktionen';
-      } else if (this.convoluteTitle === 'Hochdeutsche Gedichte 1985') {
-        this.convoluteLink = '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
-      } else if (this.convoluteTitle === 'Alemannische Gedichte 1985') {
-        this.convoluteLink = '/drucke/abgewandt-zugewandt-alemannische-gedichte';
-      } else if (this.convoluteTitle === 'Tagebuch') {
-        this.convoluteLink = '/material/tagebuecher';
-      } else if (this.convoluteTitle === 'Karten 1984') {
-        this.convoluteLink = '/manuskripte/karten-1984';
-      } else {
-        this.convoluteLink = '/drucke/verstreutes';
-      }
-    }
   }
 
 

--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="searchActivated" id="searchTermBar">
-  Suche nach: {{searchTermfromKonvolut[0]}} ({{filterPoems(poemsInGrid).length}} Resultate)
+  Suche nach: {{searchTermfromKonvolut[0]}} ({{getNumberOfShownPoems()}} Resultate)
 </div>
 <div
   [ngClass]="{'rae-poem-list-grid': viewMode == 'grid','rae-poem-list-cols': viewMode == 'cols', 'signalizeSearch': searchActivated}">

--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -36,6 +36,7 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   @Input() searchTermfromKonvolut: string;
 
   @Output() gridHeight: EventEmitter<number> = new EventEmitter<number>();
+  @Output() numberOfResults: EventEmitter<number> = new EventEmitter<number>();
   @Input() searchTermArray: Array<any>;
 
   @Input() gridTextHeight: number = 0;
@@ -52,6 +53,7 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   @Input() filterManuscriptFlag = false;
   @Input() filterTyposcriptFlag = false;
   @Input() konvolutView: boolean;
+  numberOfShownPoems: number;
 
   static highlightSingleSearchTerm(textToHighlight: string, searchTerm: string, j: number) {
     if (searchTerm === undefined) {
@@ -213,6 +215,8 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   ngAfterViewChecked() {
     if (this.poemsInGrid !== undefined && this.router.url.split('/')[ 1 ] === 'synopsen') {
       this.poemsInGrid = TextgridComponent.sortByDate(this.poemsInGrid);
+      this.numberOfShownPoems = this.getNumberOfShownPoems();
+      this.numberOfResults.emit(this.numberOfShownPoems);
     }
     this.cdr.detectChanges();
   }
@@ -308,6 +312,10 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
         updateFun(this.poemsInGrid[i]);
       }
     }
+  }
+
+  getNumberOfShownPoems(): number {
+    return this.filterPoems(this.poemsInGrid).length;
   }
 
 }

--- a/src/client/app/shared/utilities/date-format.service.ts
+++ b/src/client/app/shared/utilities/date-format.service.ts
@@ -6,6 +6,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class DateFormatService {
 
+
   germanLongMonth = [
     '',
     'Januar',
@@ -38,12 +39,29 @@ export class DateFormatService {
     'Dez.'
   ];
 
+  germanNamesOfDays = [
+    'Sonntag',
+    'Montag',
+    'Dienstag',
+    'Mittwoch',
+    'Donnerstag',
+    'Freitag',
+    'Samstag'
+  ];
+
+  private static getNameOfDay(dayOfTheWeek: number, dayNames: string[]) {
+    return dayNames[dayOfTheWeek];
+  }
+
   germanLongDate(isoDate: string): string {
-    let parts = isoDate.split('-');
-    let year = parts[ 0 ];
-    let month = this.germanLongMonth[ Number(parts[ 1 ]) ];
-    let day = parts[ 2 ].split(' ')[0] + '.';
-    return day + ' ' + month + ' ' + year;
+    const parts = isoDate.split('-');
+    const year = parts[ 0 ];
+    const monthAsNumber = parts[1];
+    const monthAsName = this.germanLongMonth[ Number(monthAsNumber) ];
+    const day = parts[ 2 ].split(' ')[0];
+    const d = new Date(+year, +monthAsNumber-1, +day);
+    const nameOfDay = DateFormatService.getNameOfDay(d.getDay(), this.germanNamesOfDays);
+    return nameOfDay + ', ' + day + '. ' + monthAsName + ' ' + year;
   }
 
   germanNumericDate(isoDate: string): string {
@@ -53,4 +71,5 @@ export class DateFormatService {
     let day = parts[ 2 ].split(' ')[0];
     return day + '.' + month + '.' + year;
   }
+
 }

--- a/src/client/app/synopse/synopse.component.html
+++ b/src/client/app/synopse/synopse.component.html
@@ -7,7 +7,8 @@
             <div class="rt-block">
               <div id="rt-mainbody">
                 <div class="component-content">
-                  <h4 style="margin:5px">Synopse: {{workTitle}} ({{results}})</h4>
+                  <h4 style="margin-left:5px; margin-top:5px; margin-bottom:0;">Synopse: {{workTitle}}</h4>
+                  <p style="margin-left:5px;">{{createNumberOfResultString()}}</p>
                   <rae-synopse-werkzeugleiste #werkzeugleiste
                                               [(showText)]="showText"
                                               [gridHeight]="gridHeight"
@@ -24,7 +25,7 @@
                   </rae-synopse-werkzeugleiste>
                   <from-poem-iri-to-textgrid-information
                     contentType="synopse"
-                    [workIRI] = "workIri"
+                    [workIRI]="workIri"
                     [poemIRIArray]="poemsIri"
                     (sendPoemInformationBack)="updatePoemInformation($event)"></from-poem-iri-to-textgrid-information>
                   <rae-textgrid #textgrid
@@ -38,7 +39,8 @@
                                 [filterManuscriptFlag]="!showManuscripts"
                                 [filterTyposcriptFlag]="!showTyposcripts"
                                 [filterDuplicatesFlag]="!showDuplicates"
-                                (gridHeight)="setGridHeight($event)">
+                                (gridHeight)="setGridHeight($event)"
+                                (numberOfResults)="setNumberOfShownPoems($event)">
                   </rae-textgrid>
                 </div>
               </div>

--- a/src/client/app/synopse/synopse.component.ts
+++ b/src/client/app/synopse/synopse.component.ts
@@ -2,7 +2,7 @@
  * Created by Sebastian Schüpbach (sebastian.schuepbach@unibas.ch) on 6/7/17.
  */
 
-import { Component, OnInit } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { Http } from '@angular/http';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Config } from '../shared/config/env.config';
@@ -12,9 +12,8 @@ import { Config } from '../shared/config/env.config';
   selector: 'rae-synopse',
   templateUrl: 'synopse.component.html'
 })
-export class SynopseComponent implements OnInit {
+export class SynopseComponent implements OnInit, AfterViewChecked {
 
-  nHits: number;
   synopseTag: string;
 
   showText: boolean;
@@ -26,6 +25,7 @@ export class SynopseComponent implements OnInit {
   poemsIri: string[] = [];
 
   poems: Array<any>;
+  numberOfShownPoems: number;
 
   results: number;
 
@@ -37,7 +37,7 @@ export class SynopseComponent implements OnInit {
 
   private sub: any;
 
-  constructor(private http: Http, private route: ActivatedRoute, router: Router) {
+  constructor(private http: Http, private route: ActivatedRoute, router: Router, private cdr: ChangeDetectorRef) {
     this.showText = true;
     this.workIri = router.url.split('/')[ 2 ];
   }
@@ -58,6 +58,10 @@ export class SynopseComponent implements OnInit {
         this.poemsIri = res.props[ 'http://www.knora.org/ontology/work#isExpressedIn' ].values;
         this.workTitle = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str;
       });
+  }
+
+  ngAfterViewChecked() {
+    this.cdr.detectChanges();
   }
 
   setColumns(cols: number) {
@@ -101,6 +105,16 @@ export class SynopseComponent implements OnInit {
 
   toggleShowDuplicates() {
     this.showDuplicates = !this.showDuplicates;
+  }
+
+  setNumberOfShownPoems(n: number) {
+    this.numberOfShownPoems = n;
+  }
+
+  createNumberOfResultString(): string {
+    return 'Anzahl Gedichte: ' + ((this.numberOfShownPoems === this.results) ?
+      this.results :
+      this.numberOfShownPoems + ' (von total ' + this.results + ')');
   }
 
 }

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -7922,10 +7922,12 @@ body #k2Container select, body #k2Container input[type="file"] {
   bottom: 15px;
   right: 15px;
   opacity: 0;
+  visibility: hidden;
   transition: all .2s ease-in-out;
 }
 
 .show-scroll {
   opacity: 1;
+  visibility: visible;
   transition: all .2s ease-in-out;
 }


### PR DESCRIPTION
## Änderungen

- Scroll-to-top button ist versteckt, wenn er nicht aktiv ist (d.h., er ist auch nicht mehr klickbar)
- Der Link zur Konvolutansicht wird aktualisiert, wenn ein neues Gedicht in der Fassungsansicht geöffnet wird
- In der Synopsenansicht werden neu neben der totalen Anzahl an Resultaten auch die Zahl der momentan angezeigten Resultate eingeblendet
- "Lange" Daten werden nun auch mit Name des Tages angezeigt (wie auf kunoraeber.ch)

## Zu testen

- Scroll-to-top-Button: Mauszeiger verändert sich nicht mehr, wenn man mit ihm in die untere rechte Ecke fährt, während die Seite ganz nach oben gescrollt ist
- Fassungsansicht: Link zur Konvolutansicht wird aktualisiert. Am besten lässt sich das testen, indem unter "Weitere Fassungen" eine Fassungen in einem anderen Konvolut angesteuert wird
- Synopse: Die gezeigte Anzahl an Fassungen stimmt mit der tatsächlichen Anzahl an Textboxen überein
- Tagesname ist korrekt (Stichprobe bspw. in Konvolutansicht) -> Kann hier getestet werden: https://www.timeanddate.com/date/weekday.html