### PR TITLE
Exclude parentheses from poem view routes

### DIFF
--- a/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.ts
+++ b/src/client/app/fassung/fassung-steckbrief/fassung-steckbrief-fassung.component.ts
@@ -32,7 +32,7 @@ export class FassungSteckbriefFassungComponent implements OnChanges {
         .subscribe(res => {
           let title = res.props[ 'http://www.knora.org/ontology/text#hasTitle' ].values[ 0 ].utf8str.split('/')[ 0 ];
           let iriPart = this.fassungIRI.split('raeber/')[ 1 ];
-          this.linkPartPoem = title + '---' + iriPart;
+          this.linkPartPoem = title.replace(/[()]/g, '') + '---' + iriPart;
         });
 
       this.sub2 = this.http.get(globalSearchVariableService.API_URL + '/search/'

--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -34,7 +34,6 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   editedPoemText: string;
   convoluteIri: string;
   convoluteTitle: string;
-  convoluteLink: string;
   synopsisIri: string = '';
   synopsisTitle: string;
   relatedPoems: any[] = [];
@@ -72,14 +71,13 @@ export class FassungComponent implements OnInit, AfterViewChecked {
   private static buildRouteTitleStringFromResultSet(resultSet: any, convoluteTitle: string) {
     const poemShortIRI = resultSet.subjects[ 0 ].value[ 3 ].split('/')[ 4 ];
     const poemTitle = resultSet.subjects[ 0 ].value[ 4 ];
-    return '/' + convoluteTitle + '/' + FassungComponent.removeSlashesInRouteElement(poemTitle) +
+    return '/' + convoluteTitle + '/' + FassungComponent.removeSlashesAndParanthesesInRouteElement(poemTitle) +
       '---' + poemShortIRI + '###' + poemTitle;
   }
 
-  private static removeSlashesInRouteElement(element: string) {
+  private static removeSlashesAndParanthesesInRouteElement(element: string) {
     return element.includes('/') ?
-      element.replace(/\//g, '') :
-      element;
+      element.replace(/[/()]/g, '') : element;
   }
 
   goToConvoluteview(searchTerm: string, page: string, convolutURl: string) {

--- a/src/client/app/register/titelregister/register-titelregister.component.ts
+++ b/src/client/app/register/titelregister/register-titelregister.component.ts
@@ -131,7 +131,7 @@ convolutePoemsQuery(konvolutTitel:string, endFassungen:boolean) {
 
 produceFassungsLink(p: any) {
   if(p && p.value[1] !== undefined && p.value[4] !== undefined && p.value[3] !== undefined) {
-    return ['/' + p.value[1]+ '/'] + p.value[4].split('/')[0] + '---' + p.value[3].split('raeber/')[1];
+    return ['/' + p.value[1]+ '/'] + p.value[4].split('/')[0].replace(/[()]/g, '') + '---' + p.value[3].split('raeber/')[1];
   } else {
     return 'Linkinformation has not arrived yet';
   }

--- a/src/client/app/shared/registerspalte/registerspalte.component.ts
+++ b/src/client/app/shared/registerspalte/registerspalte.component.ts
@@ -63,7 +63,7 @@ export class RegisterspalteComponent {
 
   createLinkToPoem(poem: CachePoem): string {
     return poem ?
-      poem.poemTitle.split('/')[ 0 ] + '---' + poem.poemIRI.split('raeber/')[ 1 ] :
+      poem.poemTitle.split('/')[ 0 ].replace(/[()]/g, '') + '---' + poem.poemIRI.split('raeber/')[ 1 ] :
       undefined;
   }
 

--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -264,9 +264,9 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   produceFassungsLink(titel: string, iri: string) {
     if (titel !== undefined && iri !== undefined) {
       if (this.konvolutTitle === undefined) {
-        return '/' + titel.split('/')[ 0 ] + '---' + iri.split('raeber/')[ 1 ];
+        return '/' + titel.split('/')[ 0 ].replace(/[()]/g, '') + '---' + iri.split('raeber/')[ 1 ];
       } else {
-        return '/' + this.konvolutTitle + '/' + titel.split('/')[ 0 ] + '---' + iri.split('raeber/')[ 1 ];
+        return '/' + this.konvolutTitle + '/' + titel.split('/')[ 0 ].replace(/[()]/g, '') + '---' + iri.split('raeber/')[ 1 ];
       }
     } else {
       return 'Linkinformation has not arrived yet';


### PR DESCRIPTION
Zu überprüfen, ob Routes zu Gedichten in Fassungsansicht keine Klammern mehr enthalten und ob ein Reloading in des Gedichtes in der Fassungsansicht (bspw. mit F5) wieder zum gleichen Gedicht führt:
- Von Textgrid (Suche, Konvolut- oder Synopsenansicht) zu einer Fassung mit Klammern im Titel (bspw. Glück (A) in Notizbuch 1979)
- Von Registerspalte zu einer Fassung mit Klammern im Titel (bspw. Glück (A)
- Von Titelregister (publizierte Gedichte) zu einem Gedicht mit Klammern (bspw. Hasengedicht (I-IX)