### PR TITLE
Convolute search in poem view must be started explicitly

### DIFF
--- a/src/client/app/shared/konvolutsuche/konvolutsuche.component.html
+++ b/src/client/app/shared/konvolutsuche/konvolutsuche.component.html
@@ -4,7 +4,7 @@
       <input mdInput type="text" placeholder="Suchbegriff" formControlName="searchTerm" [value]="defineInputValue()"
              (keyup.enter)="suche.emit(searchForm.value)" class="suchfeld">
     </md-input-container>
-    <button md-button *ngIf="!isConvoluteView" (click)="suche.emit(searchForm.value)">Suche</button>
+    <button md-raised-button *ngIf="!isConvoluteView" (click)="suche.emit(searchForm.value)">Suche</button>
     <!--<md-input-container class="suchfeld-container" *ngIf="checkIfNotizbuch(konvolutTitle)">-->
     <!--<input mdInput type="number" min="1" max="300" placeholder="Seite / Blatt" formControlName="page"-->
     <!--(keyup.enter)="suche.emit(searchForm)" class="suchfeld">-->

--- a/src/client/app/shared/konvolutsuche/konvolutsuche.component.html
+++ b/src/client/app/shared/konvolutsuche/konvolutsuche.component.html
@@ -2,8 +2,9 @@
   <form [formGroup]="searchForm">
     <md-input-container class="suchfeld-container" style="width:95% !important;">
       <input mdInput type="text" placeholder="Suchbegriff" formControlName="searchTerm" [value]="defineInputValue()"
-             (keyup.enter)="suche.emit(searchForm)" class="suchfeld">
+             (keyup.enter)="suche.emit(searchForm.value)" class="suchfeld">
     </md-input-container>
+    <button md-button *ngIf="!isConvoluteView" (click)="suche.emit(searchForm.value)">Suche</button>
     <!--<md-input-container class="suchfeld-container" *ngIf="checkIfNotizbuch(konvolutTitle)">-->
     <!--<input mdInput type="number" min="1" max="300" placeholder="Seite / Blatt" formControlName="page"-->
     <!--(keyup.enter)="suche.emit(searchForm)" class="suchfeld">-->

--- a/src/client/app/shared/konvolutsuche/konvolutsuche.component.ts
+++ b/src/client/app/shared/konvolutsuche/konvolutsuche.component.ts
@@ -1,5 +1,6 @@
-import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
 
 
 @Component({
@@ -12,27 +13,31 @@ export class KonvolutsucheComponent {
   @Output() suche = new EventEmitter<FormGroup>();
   @Input() searchTermArray: Array<string>;
   searchForm: FormGroup;
+  isConvoluteView: boolean = true;
 
-  constructor() {
+  constructor(router: Router) {
     this.searchForm = new FormGroup({
       searchTerm: new FormControl(),
       page: new FormControl()
     });
-    this.searchForm.valueChanges
-      //.debounceTime(500)
-      .subscribe(suche => this.suche.emit(suche));
+    this.isConvoluteView = !router.url.includes('---');
+    if (this.isConvoluteView) {
+      this.searchForm.valueChanges
+        .debounceTime(200)
+        .subscribe(suche => this.suche.emit(suche));
+    }
   }
 
   checkIfNotizbuch(konvolutTitle: string) {
     //console.log(konvolutTitle);
-    if(konvolutTitle) {
-      if(konvolutTitle.search('Notizbuch') !== -1) return true;
+    if (konvolutTitle) {
+      if (konvolutTitle.search('Notizbuch') !== -1) return true;
       else return false;
     } else return false;
   }
 
   defineInputValue() {
-    if(this.searchTermArray) return this.searchTermArray[0];
+    if (this.searchTermArray) return this.searchTermArray[ 0 ];
     else return null;
   }
 

--- a/src/client/app/shared/konvolutsuche/konvolutsuche.module.ts
+++ b/src/client/app/shared/konvolutsuche/konvolutsuche.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { MdInputModule } from '@angular/material';
+import { MdButtonModule, MdInputModule } from '@angular/material';
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 
@@ -9,6 +9,7 @@ import { KonvolutsucheComponent } from './konvolutsuche.component';
 @NgModule({
   imports: [
     MdInputModule,
+    MdButtonModule,
     ReactiveFormsModule,
     CommonModule,
     BrowserModule


### PR DESCRIPTION
Zu testen:
- Konvolutsuche in Fassungsansicht wird nicht mehr automatisch gestartet, sobald Zeichen in das Suchfeld eingegeben werden. Zur Auslösung der Suche muss entweder Enter gedrückt oder der Suchknopf gedrückt werden
- Suchknopf erscheint nur in Fassungsansicht. In Konvolutansicht funktioniert noch alles gleich wie zuvor (unmittelbares Auslösen der Suche nach Eingabe von Zeichen)