### PR TITLE
jetz inkludierend jahresgrenzen

### DIFF
--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -1670,8 +1670,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
           this.arg.get('zeitraumForm.zeitraumVon').value !== ''
             && this.arg.get('zeitraumForm.zeitraumBis').value !== '') {
           if(
-            (date.split('-')[0] > this.arg.get('zeitraumForm.zeitraumVon').value
-              && date.split('-')[0] < this.arg.get('zeitraumForm.zeitraumBis').value)
+            (date.split('-')[0] + 1 > this.arg.get('zeitraumForm.zeitraumVon').value
+              && date.split('-')[0] < this.arg.get('zeitraumForm.zeitraumBis').value + 1 )
           ) {
             console.log('Poem liegt im beidseitig geschlossenen Intervall');
             return true;
@@ -1680,13 +1680,13 @@ export class SucheComponent implements OnInit, AfterViewChecked {
           }
         } else if(
           (this.arg.get('zeitraumForm.zeitraumVon').value !== ''
-            && date.split('-')[0] > this.arg.get('zeitraumForm.zeitraumVon').value)
+            && date.split('-')[0] + 1 > this.arg.get('zeitraumForm.zeitraumVon').value)
         ) {
           console.log('Groesser als Linker Intervall');
           return true;
         } else if(
           (this.arg.get('zeitraumForm.zeitraumBis').value !== ''
-            && date.split('-')[0] < this.arg.get('zeitraumForm.zeitraumBis').value)
+            && date.split('-')[0] < this.arg.get('zeitraumForm.zeitraumBis').value + 1 )
         ) {
           console.log('Kleiner als Linker Intervall');
           return true;
@@ -1701,8 +1701,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
             && this.route.snapshot.queryParams[ 'zeitEnde' ] !== undefined
         ) {
           if(
-            date.split('-')[0] > this.route.snapshot.queryParams[ 'zeitBeginn' ]
-              && date.split('-')[0] < this.route.snapshot.queryParams[ 'zeitEnde' ]
+            date.split('-')[0] + 1 > this.route.snapshot.queryParams[ 'zeitBeginn' ]
+              && date.split('-')[0] < this.route.snapshot.queryParams[ 'zeitEnde' ] + 1
           ) {
             console.log('Poem liegt im beidseitig geschlossenen Intervall');
             return true;
@@ -1711,13 +1711,13 @@ export class SucheComponent implements OnInit, AfterViewChecked {
           }
         } else if(
           this.route.snapshot.queryParams[ 'zeitBeginn' ] !== undefined
-            && date.split('-')[0] > this.route.snapshot.queryParams[ 'zeitBeginn' ]
+            && date.split('-')[0] + 1 > this.route.snapshot.queryParams[ 'zeitBeginn' ]
         ) {
           console.log('Groesser als Linker Intervall');
           return true;
         } else if(
           this.route.snapshot.queryParams[ 'zeitEnde' ] !== undefined
-            && date.split('-')[0] < this.route.snapshot.queryParams[ 'zeitEnde' ]
+            && date.split('-')[0] < this.route.snapshot.queryParams[ 'zeitEnde' ] + 1
         ) {
           console.log('Kleiner als Linker Intervall');
           return true;

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -1670,8 +1670,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
           this.arg.get('zeitraumForm.zeitraumVon').value !== ''
             && this.arg.get('zeitraumForm.zeitraumBis').value !== '') {
           if(
-            (date.split('-')[0] + 1 > this.arg.get('zeitraumForm.zeitraumVon').value
-              && date.split('-')[0] < this.arg.get('zeitraumForm.zeitraumBis').value + 1 )
+            (date.split('-')[0]  >= this.arg.get('zeitraumForm.zeitraumVon').value
+              && date.split('-')[0] <= this.arg.get('zeitraumForm.zeitraumBis').value )
           ) {
             console.log('Poem liegt im beidseitig geschlossenen Intervall');
             return true;
@@ -1680,13 +1680,13 @@ export class SucheComponent implements OnInit, AfterViewChecked {
           }
         } else if(
           (this.arg.get('zeitraumForm.zeitraumVon').value !== ''
-            && date.split('-')[0] + 1 > this.arg.get('zeitraumForm.zeitraumVon').value)
+            && date.split('-')[0] >= this.arg.get('zeitraumForm.zeitraumVon').value)
         ) {
           console.log('Groesser als Linker Intervall');
           return true;
         } else if(
           (this.arg.get('zeitraumForm.zeitraumBis').value !== ''
-            && date.split('-')[0] < this.arg.get('zeitraumForm.zeitraumBis').value + 1 )
+            && date.split('-')[0] <= this.arg.get('zeitraumForm.zeitraumBis').value )
         ) {
           console.log('Kleiner als Linker Intervall');
           return true;
@@ -1701,8 +1701,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
             && this.route.snapshot.queryParams[ 'zeitEnde' ] !== undefined
         ) {
           if(
-            date.split('-')[0] + 1 > this.route.snapshot.queryParams[ 'zeitBeginn' ]
-              && date.split('-')[0] < this.route.snapshot.queryParams[ 'zeitEnde' ] + 1
+            date.split('-')[0] >= this.route.snapshot.queryParams[ 'zeitBeginn' ]
+              && date.split('-')[0] <= this.route.snapshot.queryParams[ 'zeitEnde' ]
           ) {
             console.log('Poem liegt im beidseitig geschlossenen Intervall');
             return true;
@@ -1711,13 +1711,13 @@ export class SucheComponent implements OnInit, AfterViewChecked {
           }
         } else if(
           this.route.snapshot.queryParams[ 'zeitBeginn' ] !== undefined
-            && date.split('-')[0] + 1 > this.route.snapshot.queryParams[ 'zeitBeginn' ]
+            && date.split('-')[0] >= this.route.snapshot.queryParams[ 'zeitBeginn' ]
         ) {
           console.log('Groesser als Linker Intervall');
           return true;
         } else if(
           this.route.snapshot.queryParams[ 'zeitEnde' ] !== undefined
-            && date.split('-')[0] < this.route.snapshot.queryParams[ 'zeitEnde' ] + 1
+            && date.split('-')[0] <= this.route.snapshot.queryParams[ 'zeitEnde' ]
         ) {
           console.log('Kleiner als Linker Intervall');
           return true;


### PR DESCRIPTION
Bugfix gemäss Beschreibung:

Problem: Eine Zeitraumsuche schliesst Gedichtfassungen aus, die in den eingegebenen Jahren selbst geschrieben wurden.
Beispiel: Gesucht werden soll nach Fassungen vom Gedicht "Baum" im Jahr 1954. Folgende Suchen werden abgesetzt:
 "Baum" für Zeitraum 1954 - 1954 => Kein Resultat
 "Baum" für Zeitraum 1953 - 1954 => Kein Resultat
 "Baum" für Zeitraum 1953 - 1955 => Zwei Resultate vom 1. April 1954