### PR TITLE
fixed

### DIFF
--- a/src/client/app/fassung/fassung.component.ts
+++ b/src/client/app/fassung/fassung.component.ts
@@ -136,7 +136,11 @@ export class FassungComponent implements OnInit, AfterViewChecked {
         return '/drucke/reduktionen';
       } else if (convoluteTitle === 'Hochdeutsche Gedichte 1985') {
         return '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
+      } else if (convoluteTitle === 'Abgewandt Zugewandt 1985 – Hochdeutsche Gedichte') {
+        return '/drucke/abgewandt-zugewandt-hochdeutsche-gedichte';
       } else if (convoluteTitle === 'Alemannische Gedichte 1985') {
+        return '/drucke/abgewandt-zugewandt-alemannische-gedichte';
+      } else if (convoluteTitle === 'Abgewandt Zugewandt 1985 – Alemannische Gedichte') {
         return '/drucke/abgewandt-zugewandt-alemannische-gedichte';
       } else if (convoluteTitle === 'Tagebuch') {
         return '/material/tagebuecher';


### PR DESCRIPTION
Fixed gemäss Beschreibung:
Bisher steht bloss "Hochdeutsche Gedichte 1985" o.ä.

Hintergrund:

 Im Konvolut sind die zusammengesetzten Namen wie "Abgewandt Zugewandt 1985 – Hochdeutsche Gedichte"
 Im Cache sind nur die kurzen Namen wie "Hochdeutsche Gedichte 1985"
 Da die Links von der Synopse zum Konvolut manuell gemappt sind, funktioniert das aber.

Folgeproblem:

 Wenn man vom Konvolut in die Fassung kommt und dort den Link zurück anklickt, kommt man zu "Verstreutes". Das Mapping fängt nur eine Art der Titel ab.

 Diese Routes konkurrieren einander:
    - http://raeber.nie-ine.ch/Abgewandt%20Zugewandt%201985%20%E2%80%93%20Hochdeutsche%20Gedichte/Beschw%C3%B6rung%20---kpM_3IU6SU65VF1WHLgjDA
    - http://raeber.nie-ine.ch/Hochdeutsche%20Gedichte%201985/Beschw%C3%B6rung%20---kpM_3IU6SU65VF1WHLgjDA