### PR TITLE
NIE-216: Link zu nichtexistenten Seite "Literatur" aus Navigationsleiste entfernen

### DIFF
--- a/src/client/app/core/navigationsleiste.component.html
+++ b/src/client/app/core/navigationsleiste.component.html
@@ -454,10 +454,10 @@
                       <a class="item icon" [routerLink]="['textausgaben']" routerLinkActive="active"><i
                         class="icon-star">Textausgaben</i></a>
                     </li>
-                    <li class="item293">
-                      <a class="item icon" [routerLink]="['literatur']" routerLinkActive="active"><i
-                        class="icon-star">Literatur</i></a>
-                    </li>
+                    <!--                    <li class="item293">
+                                          <a class="item icon" [routerLink]="['literatur']" routerLinkActive="active"><i
+                                            class="icon-star">Literatur</i></a>
+                                        </li>-->
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
In der Navigationsleiste soll es im Moment noch keinen Link zu "Literatur" haben, da diese Seite auch auf http://kunoraeber.ch/lyrik noch nicht verfügbar ist.