### PR TITLE
NIE-253, NIE-255, NIE-257: Fixes in Suchoberfläche

### DIFF
--- a/src/client/app/suche/suche.component.html
+++ b/src/client/app/suche/suche.component.html
@@ -7,7 +7,9 @@
             <div id="rt-mainbody">
               <div class="component-content">
 
-                <h1>Suche <sup><md-icon (click)="showHelp()" >help</md-icon></sup> </h1>
+                <h1>Suche <sup>
+                  <md-icon (click)="showHelp()" style="cursor: pointer;">help</md-icon>
+                </sup></h1>
 
 <rae-suche-werkzeugleiste> </rae-suche-werkzeugleiste>
                 Belege: {{ numberOfSearchResults }} {{ warning }}

--- a/src/client/app/suche/suchmaske/mockSucheCategories.ts
+++ b/src/client/app/suche/suchmaske/mockSucheCategories.ts
@@ -25,7 +25,7 @@ export class Suchwort {
 
 export class Notizbuch {
   notizbuchAll = true;
-  notizbuch4849 = true;
+/*  notizbuch4849 = true;
   notizbuch49 = true;
   notizbuch50 = true;
   notizbuch5051 = true;
@@ -34,16 +34,16 @@ export class Notizbuch {
   notizbuch5557 = true;
   notizbuch5758 = true;
   notizbuch5861 = true;
-  notizbuch6165 = true;
+  notizbuch6165 = true;*/
   notizbuch79 = true;
   notizbuch7982 = true;
   notizbuch8088 = true;
-  notizbuch6580 = true;
+  // notizbuch6580 = true;
 }
 
 export class Manuskript {
   manuskriptAll = true;
-  manuskriptDivers = true;
+/*  manuskriptDivers = true;
   manuskript4851 = true;
   manuskript51 = true;
   manuskript52 = true;
@@ -58,7 +58,7 @@ export class Manuskript {
   manuskript61 = true;
   manuskript62 = true;
   manuskript63 = true;
-  manuskript6465 = true;
+  manuskript6465 = true;*/
   manuskript79 = true;
   manuskript7983 = true;
   manuskriptKarten = true;
@@ -66,7 +66,7 @@ export class Manuskript {
 
 export class Typoskript {
   typoskriptAll = true;
-  typoskriptSpezialAll = true;
+/*  typoskriptSpezialAll = true;
   typoskriptSpezialKutter = true;
   typoskriptSpezialHochstrasser = true;
   typoskriptSpezialTRaeber = true;
@@ -87,11 +87,11 @@ export class Typoskript {
   typoskript61 = true;
   typoskript62 = true;
   typoskript63 = true;
-  typoskript65 = true;
+  typoskript65 = true;*/
   typoskript79 = true;
   typoskript79Spez = true;
   typoskript83 = true;
-  typoskript83Spez = true;
+  // typoskript83Spez = true;
 }
 
 export class Druck {
@@ -143,7 +143,7 @@ export class Zeitschrift {
 export class Materialien {
   materialienAll = true;
   materialienTagebuch = true;
-  materialienBrief = true;
+  // materialienBrief = true;
 }
 
 export class Textart {

--- a/src/client/app/suche/suchmaske/suchmaske.component.html
+++ b/src/client/app/suche/suchmaske/suchmaske.component.html
@@ -778,39 +778,42 @@
         </ngb-panel>
         <ngb-panel title="Textart">
           <ng-template ngbPanelContent>
+            <button md-button (click)="selectAllGenres()">
+              {{ allGenresSelected ? 'Alle abwählen' : 'Alle auswählen' }}
+            </button>
             <ul formGroupName="textartForm">
               <li class="cb-l1">
                 <md-checkbox formControlName="textartFreieVerse" color="primary"
-                             [class.green]="suchmenuForm.get('textartForm.textartFreieVerse').value || suchmenuForm.get('textartForm').pristine"
-                             [class.red]="!suchmenuForm.get('textartForm.textartFreieVerse').value && !suchmenuForm.get('textartForm').pristine">
+                             [class.green]="suchmenuForm.get('textartForm.textartFreieVerse').value"
+                             [class.red]="!suchmenuForm.get('textartForm.textartFreieVerse').value">
                   Freie Verse
                 </md-checkbox>
               </li>
               <li class="cb-l1">
                 <md-checkbox formControlName="textartGereimteVerse" color="primary"
-                             [class.green]="suchmenuForm.get('textartForm.textartGereimteVerse').value || suchmenuForm.get('textartForm').pristine"
-                             [class.red]="!suchmenuForm.get('textartForm.textartGereimteVerse').value && !suchmenuForm.get('textartForm').pristine">
+                             [class.green]="suchmenuForm.get('textartForm.textartGereimteVerse').value"
+                             [class.red]="!suchmenuForm.get('textartForm.textartGereimteVerse').value">
                   Gereimte Verse
                 </md-checkbox>
               </li>
               <li class="cb-l1">
                 <md-checkbox formControlName="textartProsa" color="primary"
-                             [class.green]="suchmenuForm.get('textartForm.textartProsa').value || suchmenuForm.get('textartForm').pristine"
-                             [class.red]="!suchmenuForm.get('textartForm.textartProsa').value && !suchmenuForm.get('textartForm').pristine">
+                             [class.green]="suchmenuForm.get('textartForm.textartProsa').value"
+                             [class.red]="!suchmenuForm.get('textartForm.textartProsa').value">
                   Rhythmische Prosa
                 </md-checkbox>
               </li>
               <li class="cb-l1">
                 <md-checkbox formControlName="textartProsanotat" color="primary"
-                             [class.green]="suchmenuForm.get('textartForm.textartProsanotat').value || suchmenuForm.get('textartForm').pristine"
-                             [class.red]="!suchmenuForm.get('textartForm.textartProsanotat').value && !suchmenuForm.get('textartForm').pristine">
+                             [class.green]="suchmenuForm.get('textartForm.textartProsanotat').value"
+                             [class.red]="!suchmenuForm.get('textartForm.textartProsanotat').value">
                   Prosanotat
                 </md-checkbox>
               </li>
               <li class="cb-l1">
                 <md-checkbox formControlName="textartBriefentwurf" color="primary"
-                             [class.green]="suchmenuForm.get('textartForm.textartBriefentwurf').value || suchmenuForm.get('textartForm').pristine"
-                             [class.red]="!suchmenuForm.get('textartForm.textartBriefentwurf').value && !suchmenuForm.get('textartForm').pristine">
+                             [class.green]="suchmenuForm.get('textartForm.textartBriefentwurf').value"
+                             [class.red]="!suchmenuForm.get('textartForm.textartBriefentwurf').value">
                   Briefentwurf
                 </md-checkbox>
               </li>

--- a/src/client/app/suche/suchmaske/suchmaske.component.html
+++ b/src/client/app/suche/suchmaske/suchmaske.component.html
@@ -36,7 +36,7 @@
                   Notizbuch
                 </md-checkbox>
               </li>
-              <li class="cb-l2" [class.hidden]="!catHidden.notizbuecher">
+         <!--     <li class="cb-l2" [class.hidden]="!catHidden.notizbuecher">
                 <md-checkbox [disabled]="true"
                              [checked]="false"
                 >Notizbuch 1948-49
@@ -95,7 +95,7 @@
                              [checked]="false"
                 >Notizbuch 1961-65
                 </md-checkbox>
-              </li>
+              </li>-->
               <li class="cb-l2" [class.hidden]="!catHidden.notizbuecher">
                 <md-checkbox [checked]="suchmenuForm.get('notizbuchForm.notizbuchAll').value" color="primary"
                              [class.green]="suchmenuForm.get('notizbuchForm.notizbuch79').value || pristineConvolutes()"
@@ -117,12 +117,12 @@
                              formControlName="notizbuch8088">Notizbuch 1980-88
                 </md-checkbox>
               </li>
-              <li class="cb-l2" [class.hidden]="!catHidden.notizbuecher">
+<!--              <li class="cb-l2" [class.hidden]="!catHidden.notizbuecher">
                 <md-checkbox [disabled]="true"
                              [checked]="false"
                 >Notizbuch 1965-80
                 </md-checkbox>
-              </li>
+              </li>-->
             </ul>
             <ul formGroupName="manuskriptForm">
               <li class="cb-l1">
@@ -141,7 +141,7 @@
                 </md-checkbox>
               </li>
 
-              <li class="cb-l2" [class.hidden]="!catHidden.manuskripte">
+<!--              <li class="cb-l2" [class.hidden]="!catHidden.manuskripte">
                 <md-checkbox [disabled]="true"
                              [checked]="false"
                 >Manuskripte 1948-51
@@ -230,7 +230,7 @@
                              [checked]="false"
                 >Manuskripte 1964-65
                 </md-checkbox>
-              </li>
+              </li>-->
               <li class="cb-l2" [class.hidden]="!catHidden.manuskripte">
                 <md-checkbox formControlName="manuskript79" color="primary"
                              [class.green]="suchmenuForm.get('manuskriptForm.manuskript79').value || pristineConvolutes()"
@@ -246,16 +246,18 @@
                 </md-checkbox>
               </li>
               <li class="cb-l2" [class.hidden]="!catHidden.manuskripte">
-                <md-checkbox [disabled]="true"
-                             [checked]="false">Karten 1984
+                <md-checkbox formControlName="manuskriptKarten" color="primary"
+                             [class.green]="suchmenuForm.get('manuskriptForm.manuskriptKarten').value || pristineConvolutes()"
+                             [class.red]="!suchmenuForm.get('manuskriptForm.manuskriptKarten').value && !pristineConvolutes()"
+                             [checked]="suchmenuForm.get('manuskriptForm.manuskriptAll').value">Karten 1984
                 </md-checkbox>
               </li>
-              <li class="cb-l2" [class.hidden]="!catHidden.manuskripte">
+<!--              <li class="cb-l2" [class.hidden]="!catHidden.manuskripte">
                 <md-checkbox [disabled]="true"
                              [checked]="false"
                 >Manuskripte divers
                 </md-checkbox>
-              </li>
+              </li>-->
             </ul>
             <ul formGroupName="typoskriptForm">
               <li class="cb-l1">
@@ -273,7 +275,7 @@
                   Typoskripte
                 </md-checkbox>
               </li>
-              <li class="cb-l2" [class.hidden]="!catHidden.typoskripte">
+<!--              <li class="cb-l2" [class.hidden]="!catHidden.typoskripte">
                 <md-checkbox [disabled]="true"
                              [checked]="false"
                 >
@@ -391,7 +393,7 @@
                 >
                   Typoskripte 1965
                 </md-checkbox>
-              </li>
+              </li>-->
               <li class="cb-l2" [class.hidden]="!catHidden.typoskripte">
                 <md-checkbox formControlName="typoskript79" color="primary"
                              [checked]="suchmenuForm.get('typoskriptForm.typoskriptAll').value"
@@ -416,7 +418,7 @@
                   Typoskripte 1983
                 </md-checkbox>
               </li>
-              <li class="cb-l2" [class.hidden]="!catHidden.typoskripte">
+<!--              <li class="cb-l2" [class.hidden]="!catHidden.typoskripte">
                 <md-checkbox [disabled]="true"
                              [checked]="false"
                 >
@@ -451,7 +453,7 @@
                 >
                   Typoskripte divers
                 </md-checkbox>
-              </li>
+              </li>-->
             </ul>
             <ul formGroupName="druckForm">
               <li class="cb-l1">
@@ -766,11 +768,11 @@
                              [checked]="suchmenuForm.get('materialienForm.materialienAll').value">Tagebuch
                 </md-checkbox>
               </li>
-              <li class="cb-l2" [class.hidden]="!catHidden.materialien">
+<!--              <li class="cb-l2" [class.hidden]="!catHidden.materialien">
                 <md-checkbox [disabled]="true"
                              [checked]="false">Brief
                 </md-checkbox>
-              </li>
+              </li>-->
             </ul>
           </ng-template>
         </ngb-panel>

--- a/src/client/app/suche/suchmaske/suchmaske.component.ts
+++ b/src/client/app/suche/suchmaske/suchmaske.component.ts
@@ -66,7 +66,8 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
     materialien: false
   };
 
-  allConvolutesSelected: boolean = true;
+  allConvolutesSelected = true;
+  allGenresSelected = true;
   loadingIndicator = true;
 
   @ViewChild(TextgridComponent)
@@ -148,7 +149,14 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
     this.toggleGroupDisabled('druckForm', 'druckAll');
     this.toggleGroupDisabled('zeitschriftForm', 'zeitschriftAll');
     this.toggleGroupDisabled('materialienForm', 'materialienAll');
-    //console.log('allConvolutesSelected: ' + this.allConvolutesSelected);
+  }
+
+  selectAllGenres() {
+    this.allGenresSelected = !this.allGenresSelected;
+    const genres = (this.suchmenuForm.get('textartForm') as FormGroup).controls;
+    for (const v in genres) {
+      genres[v].setValue(this.allGenresSelected);
+    }
   }
 
   /**

--- a/src/client/app/suche/suchmaske/suchmaske.component.ts
+++ b/src/client/app/suche/suchmaske/suchmaske.component.ts
@@ -118,18 +118,17 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
    */
   childElemsHaveSameValues(formGroupPath: string, parentFormControlName: string) {
     const children = (this.suchmenuForm.get(formGroupPath) as FormGroup).controls;
-    let res: boolean = true;
     let b: boolean;
     for (const v in children) {
       if (v !== parentFormControlName) {
-        if (b === null || children[ v ].value === b) {
+        if (!b) {
           b = children[ v ].value;
-        } else {
-          res = false;
+        } else if (children[v].value !== b) {
+          return false;
         }
       }
     }
-    return res;
+    return true;
   }
 
   pristineConvolutes() {


### PR DESCRIPTION
- NIE-253: "Eltern"-Checkboxes verhalten sich bei Änderung der Kind-Elemente konsistent:
  - Wenn alle Kind-Elemente selektiert sind, dann ist bei Elter-Element Häckchen gesetzt und Schrit grün
  - Wenn ein Teil der Kind-Elemente selektiert sind, dann ist bei Elter-Element "Minus" gesetzt und Schrift blau
  - Wenn kein Kind-Element selektiert ist, dann ist bei Elter-Element Checkbox leer und Schrift rot
- NIE-255: Button "Alle abwählen" nun auch in Kategorie Textart
- Checkboxes für Konvolute, die noch nicht freigeschaltet sind, werden nicht mehr angezeigt (und sind nicht bloss deaktiviert)
- NIE-257: Über Hilfe-Icon links oben in Suchansicht wird der Mauszeiger zu einem "Pointer" (analog zu einem Link)