### PR TITLE
NIE-239 / NIE-248: Optimale Nutzung des horizontalen Platzes in Textgrid

### DIFF
--- a/src/client/app/konvolut/konvolut.component.ts
+++ b/src/client/app/konvolut/konvolut.component.ts
@@ -134,13 +134,13 @@ export class KonvolutComponent implements OnInit {
   setColumns(cols: number) {
     switch (cols) {
       case 1:
-        this.columns = '93%';
+        this.columns = '100%';
         break;
       case 2:
-        this.columns = '43%';
+        this.columns = '45%';
         break;
       case 3:
-        this.columns = '26%';
+        this.columns = '29%';
         break;
     }
   }

--- a/src/client/app/shared/textgrid/textgrid.component.css
+++ b/src/client/app/shared/textgrid/textgrid.component.css
@@ -13,9 +13,9 @@
 .rae-poem-container {
   display: inline-block;
   vertical-align: top;
-  width: 43%;
+  width: 45%;
   padding: 5px;
-  margin: 16px;
+  margin: 8px;
   white-space: normal;
 }
 
@@ -47,7 +47,7 @@ md-card-content {
 
 .rae-poem-card-grid {
   height: 90%;
-  width: 90%;
+  width: 100%;
 }
 
 .hidden {

--- a/src/client/app/shared/textgrid/textgrid.component.ts
+++ b/src/client/app/shared/textgrid/textgrid.component.ts
@@ -29,7 +29,7 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   @Input() contentType: string = 'suche'; // synopse OR konvolut OR suche
   @Input() viewMode: string = 'grid';
   @Input() showText: boolean = true;
-  @Input() columns: string = '43%';
+  @Input() columns: string = '45%';
   @Input() rahmen: boolean = true;
   @Input() poemsInGrid: Array<any>;
   @Input() resetPoems: string;
@@ -159,7 +159,6 @@ export class TextgridComponent implements OnChanges, AfterViewChecked {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    console.log(this.searchTermfromKonvolut);
     if (this.searchTermfromKonvolut) {
       if (this.searchTermfromKonvolut[ 0 ] && this.searchTermfromKonvolut[ 0 ].length > 2) {
         this.searchInKonvolut = true;

--- a/src/client/app/suche/suche-darstellungsoptionen.service.ts
+++ b/src/client/app/suche/suche-darstellungsoptionen.service.ts
@@ -14,7 +14,7 @@ export class SucheDarstellungsoptionenService {
   private showTextFlag: boolean = true;
   private textboxHeight: number = 0;
   private numberOfColumns: number = 3;
-  private relativeSizesOfColumns: [string, string, string] = ['93%', '43%', '26%'];
+  private relativeSizesOfColumns: [string, string, string] = ['100%', '45%', '29%'];
   private textsHaveAlignedFrames: boolean = false;
 
   textboxHeight$ = this.textboxHeightSource.asObservable();

--- a/src/client/app/suche/suchmaske/suchmaske.component.ts
+++ b/src/client/app/suche/suchmaske/suchmaske.component.ts
@@ -34,7 +34,7 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   @Input() loadingIndicatorInput: boolean;
   @Input() lastSearchTerm: string;
 
-  relativeSizeOfColumns: string = '43%';
+  relativeSizeOfColumns: string = '45%';
   textboxHeight: number = 0;
   textsHaveAlignedFrames: boolean = false;
   showTexts: boolean = true;

--- a/src/client/app/synopse/synopse.component.html
+++ b/src/client/app/synopse/synopse.component.html
@@ -3,7 +3,7 @@
     <div class="rt-container">
       <div id="rt-main" class="mb9-sa3">
         <div class="rt-container">
-          <div class="rt-grid-9 ">
+          <div class="rt-grid-12">
             <div class="rt-block">
               <div id="rt-mainbody">
                 <div class="component-content">

--- a/src/client/app/synopse/synopse.component.ts
+++ b/src/client/app/synopse/synopse.component.ts
@@ -68,13 +68,13 @@ export class SynopseComponent implements OnInit, AfterViewChecked {
   setColumns(cols: number) {
     switch (cols) {
       case 1:
-        this.columns = '93%';
+        this.columns = '100%';
         break;
       case 2:
-        this.columns = '43%';
+        this.columns = '45%';
         break;
       case 3:
-        this.columns = '26%';
+        this.columns = '29%';
         break;
     }
   }


### PR DESCRIPTION
Zu testen:
- In Textgrid funktioniert Spaltenansicht wie erwartet (auch bei Bildschirmbreiten bis hinunter zu ca. 770px), d.h. auf einer Zeile wird immer die korrekte Anzahl an Textkästchen angezeigt (1, 2 oder 3)
- Zudem sollen sich horizontal benachbarte Textkästchen nicht überlappen, sondern höchstens direkt aneinandergrenzen
- In Synopsenansicht wird ganzer horizontaler Platz von Textgrid ausgenutzt
- Auch bei Synopsenansicht gilt: 1, 2 oder 3 Spalten werden korrekt angezeigt