### PR TITLE
Nie 278 refactor suchmaske konvolut iri mapping

### DIFF
--- a/src/client/app/suche/suchServices/suchModel.service.ts
+++ b/src/client/app/suche/suchServices/suchModel.service.ts
@@ -1,0 +1,390 @@
+export function createsuchmaskeKonvolutIRIMapping() {
+  var convoluteIndex = -1;
+  function createConvoluteIndex() {
+    convoluteIndex += 1;
+    return convoluteIndex;
+  }
+  var suchmaskeKonvolutIRIMapping = [
+    {
+      'konvolut': 'notizbuch-1979',
+      'suchmaskeKonvolutName': 'notizbuch79',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Notizbuch 1979',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'notizbuchForm'
+    },
+    {
+      'konvolut': 'notizbuch-1979-1982',
+      'suchmaskeKonvolutName': 'notizbuch7982',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Notizbuch 1979 - 82',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'notizbuchForm'
+    },
+    {
+      'konvolut': 'notizbuch-1980-1988',
+      'suchmaskeKonvolutName': 'notizbuch8088',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Notizbuch 1980 - 1988',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'notizbuchForm'
+    },
+    {
+      'konvolut': 'manuskripte-1979',
+      'suchmaskeKonvolutName': 'manuskript79',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Manuskripte 1979',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'manuskriptForm'
+    },
+    {
+      'konvolut': 'manuskripte-1979-1983',
+      'suchmaskeKonvolutName': 'manuskript7983',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Manuskripte 1979 - 1983',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'manuskriptForm'
+    },
+    {
+      'konvolut': 'karten-1984',
+      'suchmaskeKonvolutName': 'manuskriptKarten',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Karten 1984',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'manuskriptForm'
+    },
+    {
+      'konvolut': 'typoskripte-1979',
+      'suchmaskeKonvolutName': 'typoskript79',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Typoskripte 1979',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'typoskriptForm'
+    },
+    {
+      'konvolut': 'typoskripte-1979-spez',
+      'suchmaskeKonvolutName': 'typoskript79Spez',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Typoskripte 1979 - spez',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'typoskriptForm'
+    },
+    {
+      'konvolut': 'typoskripte-1983',
+      'suchmaskeKonvolutName': 'typoskript83',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Typoskripte 1983',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'typoskriptForm'
+    },
+    {
+      'konvolut': 'gesicht-im-mittag',
+      'suchmaskeKonvolutName': 'druckGesicht',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Gesicht im Mittag',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
+    },
+    {
+      'konvolut': 'die-verwandelten-schiffe',
+      'suchmaskeKonvolutName': 'druckSchiffe',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Die verwandelten Schiffe',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
+    },
+    {
+      'konvolut': 'gedichte',
+      'suchmaskeKonvolutName': 'druckGedichte',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Gedichte',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
+    },
+    {
+      'konvolut': 'flussufer',
+      'suchmaskeKonvolutName': 'druckFlussufer',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Flussufer',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
+    },
+    {
+      'konvolut': 'reduktionen',
+      'suchmaskeKonvolutName': 'druckReduktionen',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Reduktionen',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
+    },
+    {
+      'konvolut': 'abgewandt-zugewandt-hochdeutsche-gedichte',
+      'suchmaskeKonvolutName': 'druckAbgewandtAll',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Abgewandt Zugewandt 1985 – Hochdeutsche Gedichte',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
+    },
+    {
+      'konvolut': 'abgewandt-zugewandt-alemannische-gedichte',
+      'suchmaskeKonvolutName': 'druckAbgewandtAll',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Abgewandt Zugewandt 1985 – Alemannische Gedichte',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
+    },
+    {
+      'konvolut': 'akzente',
+      'suchmaskeKonvolutName': 'zeitschriftAkzente',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Akzente',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'blaetter+bilder',
+      'suchmaskeKonvolutName': 'zeitschriftBlaetter',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Blätter + Bilder',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftSchoenste',
+      'suchmaskeKonvolutName': 'zeitschriftSchoenste',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Schönste',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftTag',
+      'suchmaskeKonvolutName': 'zeitschriftTag',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Tag',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftTat',
+      'suchmaskeKonvolutName': 'zeitschriftTat',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Tat',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftZeit',
+      'suchmaskeKonvolutName': 'zeitschriftZeit',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'DIE ZEIT',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftEnsemble',
+      'suchmaskeKonvolutName': 'zeitschriftEnsemble',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'ensemble',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftHortulus',
+      'suchmaskeKonvolutName': 'zeitschriftHortulus',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Hortulus',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftJahresring',
+      'suchmaskeKonvolutName': 'zeitschriftJahresring',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Jahresring',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftKonturen',
+      'suchmaskeKonvolutName': 'zeitschriftKonturen',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Konturen',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftLNN',
+      'suchmaskeKonvolutName': 'zeitschriftLNN',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Luzerner Neueste Nachrichten',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftLadZ',
+      'suchmaskeKonvolutName': 'zeitschriftLadZ',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Lyrik aus dieser Zeit',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftLuZ',
+      'suchmaskeKonvolutName': 'zeitschriftLuZ',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Lyrik unserer Zeit',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftMerkur',
+      'suchmaskeKonvolutName': 'zeitschriftMerkur',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Merkur',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftDeutscheHefte',
+      'suchmaskeKonvolutName': 'zeitschriftDeutscheHefte',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Neue Deutsche Hefte',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftNZN',
+      'suchmaskeKonvolutName': 'zeitschriftNZN',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Neue Zürcher Nachrichten',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftNZZ',
+      'suchmaskeKonvolutName': 'zeitschriftNZZ',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Neue Zürcher Zeitung',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftRenaissance',
+      'suchmaskeKonvolutName': 'zeitschriftRenaissance',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Renaissance',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftRundschau',
+      'suchmaskeKonvolutName': 'zeitschriftRundschau',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Schweizer Rundschau',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftSueddeutsche',
+      'suchmaskeKonvolutName': 'zeitschriftSueddeutsche',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Sueddeutsche Zeitung',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'zeitschriftWortTat',
+      'suchmaskeKonvolutName': 'zeitschriftWortTat',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Wort und Tat',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
+    },
+    {
+      'konvolut': 'materialienTagebuch',
+      'suchmaskeKonvolutName': 'materialienTagebuch',
+      'enabled': true,
+      'IRI': 'undefined',
+      'memberPoems': new Set(),
+      'officialName': 'Tagebuch',
+      'index': createConvoluteIndex(),
+      'suchmaskeFormName': 'materialienForm'
+    }
+  ];
+  return suchmaskeKonvolutIRIMapping;
+}

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -106,6 +106,11 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   ];
   arg: AbstractControl;
   rightProperty: string;
+  convoluteIndex = 0;
+  createConvoluteIndex() {
+    this.convoluteIndex += 1;
+    return this.convoluteIndex;
+  }
   suchmaskeKonvolutIRIMapping = [
     {
       'konvolut': 'notizbuch-1979',
@@ -113,7 +118,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Notizbuch 1979'
+      'officialName': 'Notizbuch 1979',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'notizbuch-1979-1982',

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -7,7 +7,7 @@ import { Location } from '@angular/common';
 import { MdDialog } from '@angular/material';
 import { SuchmaskeHilfeComponent } from './suchmaske-hilfe/suchmaske-hilfe.component';
 import { CachePoem } from '../shared/textgrid/cache-poem';
-
+import { createsuchmaskeKonvolutIRIMapping } from './suchServices/suchModel.service';
 
 @Component({
   moduleId: module.id,
@@ -21,11 +21,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   myResources: Array<any>;
   myProperties: Array<any>;
   responseArray: Array<any>;
-  searchResult: Array<any>;
   selectedResource: string;
   selectedProperty: string;
-  boolOperator: string;
-  encodedURL: string;
   searchForVal: string;
   query: string;
   availableboolOperators = [
@@ -41,7 +38,6 @@ export class SucheComponent implements OnInit, AfterViewChecked {
     { name: '!like', operator: '!LIKE' },
     { name: 'match_boolean', operator: 'MATCH_BOOLEAN' }
   ];
-  arraySize: number;
   array = [
     1
   ];
@@ -51,7 +47,6 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   l: number;
   m: number;
   o: number;
-  numberOfSearchResultsOld: number;
   isAlreadyInArray = 0;
   helperMap = new Map();
   mapOfAllQueries = new Map();
@@ -107,388 +102,7 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   arg: AbstractControl;
   rightProperty: string;
   convoluteIndex = -1;
-  suchmaskeKonvolutIRIMapping = [
-    {
-      'konvolut': 'notizbuch-1979',
-      'suchmaskeKonvolutName': 'notizbuch79',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Notizbuch 1979',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'notizbuchForm'
-    },
-    {
-      'konvolut': 'notizbuch-1979-1982',
-      'suchmaskeKonvolutName': 'notizbuch7982',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Notizbuch 1979 - 82',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'notizbuchForm'
-    },
-    {
-      'konvolut': 'notizbuch-1980-1988',
-      'suchmaskeKonvolutName': 'notizbuch8088',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Notizbuch 1980 - 1988',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'notizbuchForm'
-    },
-    {
-      'konvolut': 'manuskripte-1979',
-      'suchmaskeKonvolutName': 'manuskript79',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Manuskripte 1979',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'manuskriptForm'
-    },
-    {
-      'konvolut': 'manuskripte-1979-1983',
-      'suchmaskeKonvolutName': 'manuskript7983',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Manuskripte 1979 - 1983',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'manuskriptForm'
-    },
-    {
-      'konvolut': 'karten-1984',
-      'suchmaskeKonvolutName': 'manuskriptKarten',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Karten 1984',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'manuskriptForm'
-    },
-    {
-      'konvolut': 'typoskripte-1979',
-      'suchmaskeKonvolutName': 'typoskript79',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Typoskripte 1979',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'typoskriptForm'
-    },
-    {
-      'konvolut': 'typoskripte-1979-spez',
-      'suchmaskeKonvolutName': 'typoskript79Spez',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Typoskripte 1979 - spez',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'typoskriptForm'
-    },
-    {
-      'konvolut': 'typoskripte-1983',
-      'suchmaskeKonvolutName': 'typoskript83',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Manuskripte 1983',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'typoskriptForm'
-    },
-    {
-      'konvolut': 'gesicht-im-mittag',
-      'suchmaskeKonvolutName': 'druckGesicht',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Gesicht im Mittag',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'druckForm'
-    },
-    {
-      'konvolut': 'die-verwandelten-schiffe',
-      'suchmaskeKonvolutName': 'druckSchiffe',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Die verwandelten Schiffe',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'druckForm'
-    },
-    {
-      'konvolut': 'gedichte',
-      'suchmaskeKonvolutName': 'druckGedichte',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Gedichte',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'druckForm'
-    },
-    {
-      'konvolut': 'flussufer',
-      'suchmaskeKonvolutName': 'druckFlussufer',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Flussufer',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'druckForm'
-    },
-    {
-      'konvolut': 'reduktionen',
-      'suchmaskeKonvolutName': 'druckReduktionen',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Reduktionen',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'druckForm'
-    },
-    {
-      'konvolut': 'abgewandt-zugewandt-hochdeutsche-gedichte',
-      'suchmaskeKonvolutName': 'druckAbgewandtAll',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Abgewandt Zugewandt 1985 – Hochdeutsche Gedichte',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'druckForm'
-    },
-    {
-      'konvolut': 'abgewandt-zugewandt-alemannische-gedichte',
-      'suchmaskeKonvolutName': 'druckAbgewandtAll',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Abgewandt Zugewandt 1985 – Alemannische Gedichte',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'druckForm'
-    },
-    {
-      'konvolut': 'akzente',
-      'suchmaskeKonvolutName': 'zeitschriftAkzente',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Akzente',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'blaetter+bilder',
-      'suchmaskeKonvolutName': 'zeitschriftBlaetter',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Blätter + Bilder',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftSchoenste',
-      'suchmaskeKonvolutName': 'zeitschriftSchoenste',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Schönste',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftTag',
-      'suchmaskeKonvolutName': 'zeitschriftTag',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Tag',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftTat',
-      'suchmaskeKonvolutName': 'zeitschriftTat',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Tat',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftZeit',
-      'suchmaskeKonvolutName': 'zeitschriftZeit',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'DIE ZEIT',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftEnsemble',
-      'suchmaskeKonvolutName': 'zeitschriftEnsemble',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'ensemble',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftHortulus',
-      'suchmaskeKonvolutName': 'zeitschriftHortulus',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Hortulus',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftJahresring',
-      'suchmaskeKonvolutName': 'zeitschriftJahresring',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Jahresring',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftKonturen',
-      'suchmaskeKonvolutName': 'zeitschriftKonturen',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Konturen',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftLNN',
-      'suchmaskeKonvolutName': 'zeitschriftLNN',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Luzerner Neueste Nachrichten',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftLadZ',
-      'suchmaskeKonvolutName': 'zeitschriftLadZ',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Lyrik aus dieser Zeit',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftLuZ',
-      'suchmaskeKonvolutName': 'zeitschriftLuZ',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Lyrik unserer Zeit',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftMerkur',
-      'suchmaskeKonvolutName': 'zeitschriftMerkur',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Merkur',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftDeutscheHefte',
-      'suchmaskeKonvolutName': 'zeitschriftDeutscheHefte',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Neue Deutsche Hefte',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftNZN',
-      'suchmaskeKonvolutName': 'zeitschriftNZN',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Neue Zürcher Nachrichten',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftNZZ',
-      'suchmaskeKonvolutName': 'zeitschriftNZZ',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Neue Zürcher Zeitung',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftRenaissance',
-      'suchmaskeKonvolutName': 'zeitschriftRenaissance',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Renaissance',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftRundschau',
-      'suchmaskeKonvolutName': 'zeitschriftRundschau',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Schweizer Rundschau',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftSueddeutsche',
-      'suchmaskeKonvolutName': 'zeitschriftSueddeutsche',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Sueddeutsche Zeitung',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'zeitschriftWortTat',
-      'suchmaskeKonvolutName': 'zeitschriftWortTat',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Wort und Tat',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    },
-    {
-      'konvolut': 'materialienTagebuch',
-      'suchmaskeKonvolutName': 'materialienTagebuch',
-      'enabled': true,
-      'IRI': 'undefined',
-      'memberPoems': new Set(),
-      'officialName': 'Tagebuch',
-      'index': this.createConvoluteIndex(),
-      'suchmaskeFormName': 'zeitschriftForm'
-    }
-  ];
+  suchmaskeKonvolutIRIMapping = createsuchmaskeKonvolutIRIMapping();
   poemResTypes = [
     'http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber%23PoemNote',
     'http%3A%2F%2Fwww.knora.org%2Fontology%2Fkuno-raeber%23HandwrittenPoem',
@@ -503,10 +117,6 @@ export class SucheComponent implements OnInit, AfterViewChecked {
     this.route.params.subscribe(params => console.log(params));
   }
 
-  createConvoluteIndex() {
-    this.convoluteIndex += 1;
-    return this.convoluteIndex;
-  }
 
   ngAfterViewChecked() {
     this.cdr.detectChanges();
@@ -526,7 +136,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
     this.arg = arg;
     this.updateSuchmaskeKonvolutIRIMapping(arg);
     //Send String to Parser:
-    this.inputSearchStringToBeParsed = arg.get('suchwortForm').value.suchwortInput;
+    if (arg.get('suchwortForm').value.suchwortInput !== '') this.inputSearchStringToBeParsed = arg.get('suchwortForm').value.suchwortInput;
+    else this.inputSearchStringToBeParsed = this.searchTerm;
     this.currentPath = '/suche?wort=' + this.inputSearchStringToBeParsed;
     this.location.replaceState(this.currentPath);
   }
@@ -895,52 +506,19 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       && arg.get('zeitschriftForm').pristine
     ) {
       //console.log('Perform Search in all convolutes');
-      console.log(this.suchmaskeKonvolutIRIMapping);
+      //console.log(this.suchmaskeKonvolutIRIMapping);
     } else {
       for ( let konvolut of this.suchmaskeKonvolutIRIMapping ) {
+        //console.log(konvolut.suchmaskeFormName + '.' + konvolut.suchmaskeKonvolutName);
         konvolut.enabled = arg.get( konvolut.suchmaskeFormName + '.' + konvolut.suchmaskeKonvolutName ).value;
       }
     }
   }
   updateQueryParamsInURL() {
+    for ( let konvolut of this.suchmaskeKonvolutIRIMapping ) {
+      this.currentPath += '&' + konvolut.suchmaskeKonvolutName + '=' + konvolut.enabled;
+    }
     this.currentPath = this.currentPath +
-      '&notizbuch79=' + this.suchmaskeKonvolutIRIMapping[ 0 ].enabled +
-      '&notizbuch7982=' + this.suchmaskeKonvolutIRIMapping[ 1 ].enabled +
-      '&notizbuch8088=' + this.suchmaskeKonvolutIRIMapping[ 2 ].enabled +
-      '&manuskript79=' + this.suchmaskeKonvolutIRIMapping[ 3 ].enabled +
-      '&manuskript7983=' + this.suchmaskeKonvolutIRIMapping[ 4 ].enabled +
-      '&manuskriptKarten=' + this.suchmaskeKonvolutIRIMapping[ 5 ].enabled +
-      '&typoskript79=' + this.suchmaskeKonvolutIRIMapping[ 6 ].enabled +
-      '&typoskript79Spez=' + this.suchmaskeKonvolutIRIMapping[ 7 ].enabled +
-      '&typoskript83=' + this.suchmaskeKonvolutIRIMapping[ 8 ].enabled +
-      '&druckGesicht=' + this.suchmaskeKonvolutIRIMapping[ 9 ].enabled +
-      '&druckSchiffe=' + this.suchmaskeKonvolutIRIMapping[ 10 ].enabled +
-      '&druckGedichte=' + this.suchmaskeKonvolutIRIMapping[ 11 ].enabled +
-      '&druckFlussufer=' + this.suchmaskeKonvolutIRIMapping[ 12 ].enabled +
-      '&druckReduktionen=' + this.suchmaskeKonvolutIRIMapping[ 13 ].enabled +
-      '&zeitschriftAkzente=' + this.suchmaskeKonvolutIRIMapping[ 14 ].enabled +
-      '&zeitschriftBlaetter=' + this.suchmaskeKonvolutIRIMapping[ 15 ].enabled +
-      '&zeitschriftSchoenste=' + this.suchmaskeKonvolutIRIMapping[ 16 ].enabled +
-      '&zeitschriftTag=' + this.suchmaskeKonvolutIRIMapping[ 17 ].enabled +
-      '&zeitschriftTat=' + this.suchmaskeKonvolutIRIMapping[ 18 ].enabled +
-      '&zeitschriftZeit=' + this.suchmaskeKonvolutIRIMapping[ 19 ].enabled +
-      '&zeitschriftEnsemble=' + this.suchmaskeKonvolutIRIMapping[ 20 ].enabled +
-      '&zeitschriftHortulus=' + this.suchmaskeKonvolutIRIMapping[ 21 ].enabled +
-      '&zeitschriftJahresring=' + this.suchmaskeKonvolutIRIMapping[ 22 ].enabled +
-      '&zeitschriftKonturen=' + this.suchmaskeKonvolutIRIMapping[ 23 ].enabled +
-      '&zeitschriftLNN=' + this.suchmaskeKonvolutIRIMapping[ 24 ].enabled +
-      '&zeitschriftLadZ=' + this.suchmaskeKonvolutIRIMapping[ 25 ].enabled +
-      '&zeitschriftLuZ=' + this.suchmaskeKonvolutIRIMapping[ 26 ].enabled +
-      '&zeitschriftMerkur=' + this.suchmaskeKonvolutIRIMapping[ 27 ].enabled +
-      '&zeitschriftDeutscheHefte=' + this.suchmaskeKonvolutIRIMapping[ 28 ].enabled +
-      '&zeitschriftNZN=' + this.suchmaskeKonvolutIRIMapping[ 29 ].enabled +
-      '&zeitschriftNZZ=' + this.suchmaskeKonvolutIRIMapping[ 30 ].enabled +
-      '&zeitschriftRenaissance=' + this.suchmaskeKonvolutIRIMapping[ 31 ].enabled +
-      '&zeitschriftRundschau=' + this.suchmaskeKonvolutIRIMapping[ 32 ].enabled +
-      '&zeitschriftSueddeutsche=' + this.suchmaskeKonvolutIRIMapping[ 33 ].enabled +
-      '&zeitschriftWortTat=' + this.suchmaskeKonvolutIRIMapping[ 34 ].enabled +
-      '&materialienTagebuch=' + this.suchmaskeKonvolutIRIMapping[ 35 ].enabled +
-      '&druckAbgewandtAll=' + this.suchmaskeKonvolutIRIMapping[ 36 ].enabled +
       '&textartFreieVerse=' + this.arg.get('textartForm.textartFreieVerse').value +
       '&textartProsanotat=' + this.arg.get('textartForm.textartProsanotat').value +
       '&textartProsa=' + this.arg.get('textartForm.textartProsa').value +

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -106,11 +106,7 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   ];
   arg: AbstractControl;
   rightProperty: string;
-  convoluteIndex = 0;
-  createConvoluteIndex() {
-    this.convoluteIndex += 1;
-    return this.convoluteIndex;
-  }
+  convoluteIndex = -1;
   suchmaskeKonvolutIRIMapping = [
     {
       'konvolut': 'notizbuch-1979',
@@ -127,7 +123,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Notizbuch 1979 - 82'
+      'officialName': 'Notizbuch 1979 - 82',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'notizbuch-1980-1988',
@@ -135,7 +132,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Notizbuch 1980 - 1988'
+      'officialName': 'Notizbuch 1980 - 1988',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'manuskripte-1979',
@@ -143,7 +141,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Manuskripte 1979'
+      'officialName': 'Manuskripte 1979',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'manuskripte-1979-1983',
@@ -151,7 +150,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Manuskripte 1979 - 1983'
+      'officialName': 'Manuskripte 1979 - 1983',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'karten-1984',
@@ -159,7 +159,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Karten 1984'
+      'officialName': 'Karten 1984',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'typoskripte-1979',
@@ -167,7 +168,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Typoskripte 1979'
+      'officialName': 'Typoskripte 1979',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'typoskripte-1979-spez',
@@ -175,7 +177,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Typoskripte 1979 - spez'
+      'officialName': 'Typoskripte 1979 - spez',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'typoskripte-1983',
@@ -183,7 +186,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Manuskripte 1983'
+      'officialName': 'Manuskripte 1983',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'gesicht-im-mittag',
@@ -191,7 +195,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Gesicht im Mittag'
+      'officialName': 'Gesicht im Mittag',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'die-verwandelten-schiffe',
@@ -199,7 +204,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Die verwandelten Schiffe'
+      'officialName': 'Die verwandelten Schiffe',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'gedichte',
@@ -207,7 +213,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Gedichte'
+      'officialName': 'Gedichte',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'flussufer',
@@ -215,7 +222,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Flussufer'
+      'officialName': 'Flussufer',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'reduktionen',
@@ -223,7 +231,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Reduktionen'
+      'officialName': 'Reduktionen',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'abgewandt-zugewandt-hochdeutsche-gedichte',
@@ -231,7 +240,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Abgewandt Zugewandt 1985 – Hochdeutsche Gedichte'
+      'officialName': 'Abgewandt Zugewandt 1985 – Hochdeutsche Gedichte',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'abgewandt-zugewandt-alemannische-gedichte',
@@ -239,7 +249,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Abgewandt Zugewandt 1985 – Alemannische Gedichte'
+      'officialName': 'Abgewandt Zugewandt 1985 – Alemannische Gedichte',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'akzente',
@@ -247,7 +258,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Akzente'
+      'officialName': 'Akzente',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'blaetter+bilder',
@@ -255,7 +267,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Blätter + Bilder'
+      'officialName': 'Blätter + Bilder',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftSchoenste',
@@ -263,7 +276,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Schönste'
+      'officialName': 'Schönste',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftTag',
@@ -271,7 +285,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Tag'
+      'officialName': 'Tag',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftTat',
@@ -279,7 +294,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Tat'
+      'officialName': 'Tat',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftZeit',
@@ -287,7 +303,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'DIE ZEIT'
+      'officialName': 'DIE ZEIT',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftEnsemble',
@@ -295,7 +312,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'ensemble'
+      'officialName': 'ensemble',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftHortulus',
@@ -303,7 +321,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Hortulus'
+      'officialName': 'Hortulus',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftJahresring',
@@ -311,7 +330,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Jahresring'
+      'officialName': 'Jahresring',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftKonturen',
@@ -319,7 +339,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Konturen'
+      'officialName': 'Konturen',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftLNN',
@@ -327,7 +348,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Luzerner Neueste Nachrichten'
+      'officialName': 'Luzerner Neueste Nachrichten',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftLadZ',
@@ -335,7 +357,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Lyrik aus dieser Zeit'
+      'officialName': 'Lyrik aus dieser Zeit',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftLuZ',
@@ -343,7 +366,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Lyrik unserer Zeit'
+      'officialName': 'Lyrik unserer Zeit',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftMerkur',
@@ -351,7 +375,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Merkur'
+      'officialName': 'Merkur',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftDeutscheHefte',
@@ -359,7 +384,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Neue Deutsche Hefte'
+      'officialName': 'Neue Deutsche Hefte',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftNZN',
@@ -367,7 +393,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Neue Zürcher Nachrichten'
+      'officialName': 'Neue Zürcher Nachrichten',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftNZZ',
@@ -375,7 +402,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Neue Zürcher Zeitung'
+      'officialName': 'Neue Zürcher Zeitung',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftRenaissance',
@@ -383,7 +411,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Renaissance'
+      'officialName': 'Renaissance',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftRundschau',
@@ -391,7 +420,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Schweizer Rundschau'
+      'officialName': 'Schweizer Rundschau',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftSueddeutsche',
@@ -399,7 +429,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Sueddeutsche Zeitung'
+      'officialName': 'Sueddeutsche Zeitung',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'zeitschriftWortTat',
@@ -407,7 +438,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Wort und Tat'
+      'officialName': 'Wort und Tat',
+      'index': this.createConvoluteIndex()
     },
     {
       'konvolut': 'materialienTagebuch',
@@ -415,7 +447,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'enabled': true,
       'IRI': 'undefined',
       'memberPoems': new Set(),
-      'officialName': 'Tagebuch'
+      'officialName': 'Tagebuch',
+      'index': this.createConvoluteIndex()
     }
   ];
   poemResTypes = [
@@ -430,6 +463,11 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   constructor(public dialog: MdDialog, private http: Http, private route: ActivatedRoute, private location: Location,
               private cdr: ChangeDetectorRef) {
     this.route.params.subscribe(params => console.log(params));
+  }
+
+  createConvoluteIndex() {
+    this.convoluteIndex += 1;
+    return this.convoluteIndex;
   }
 
   ngAfterViewChecked() {
@@ -467,82 +505,10 @@ export class SucheComponent implements OnInit, AfterViewChecked {
     }
     console.log(this.suchmaskeKonvolutIRIMapping);
     if (this.route.snapshot.queryParams[ 'wort' ]) {
-      //console.log('Start search immediately');
-      this.suchmaskeKonvolutIRIMapping[ 0 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'notizbuch79' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 1 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'notizbuch7982' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 2 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'notizbuch8088' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 3 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'manuskript79' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 4 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'manuskript7983' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 5 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'manuskriptKarten' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 6 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'typoskript79' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 7 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'typoskript79Spez' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 8 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'typoskript83' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 9 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'druckGesicht' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 10 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'druckSchiffe' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 11 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'druckGedichte' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 12 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'druckFlussufer' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 13 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'druckReduktionen' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 14 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftAkzente' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 15 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftBlaetter' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 16 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftSchoenste' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 17 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftTag' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 18 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftTat' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 19 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftZeit' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 20 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftEnsemble' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 21 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftHortulus' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 22 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftJahresring' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 23 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftKonturen' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 24 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftLNN' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 25 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftLadZ' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 26 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftLuZ' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 27 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftMerkur' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 28 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftDeutscheHefte' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 29 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftNZN' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 30 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftNZZ' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 31 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftRenaissance' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 32 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftRundschau' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 33 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftSueddeutsche' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 34 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'zeitschriftWortTat' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 35 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'materialienTagebuch' ],true);
-      this.suchmaskeKonvolutIRIMapping[ 36 ].enabled
-        = this.updateFilterParams(this.route.snapshot.queryParams[ 'druckAbgewandtAll' ],true);
-      //console.log(this.suchmaskeKonvolutIRIMapping);
+      for ( let konvolut of this.suchmaskeKonvolutIRIMapping ) {
+        console.log(konvolut);
+        konvolut.enabled = this.updateFilterParams(this.route.snapshot.queryParams[ konvolut.suchmaskeKonvolutName ], true);
+      }
       this.startSearchImmediately = true;
       this.searchTermArray = [];
       this.searchTermArray[this.searchTermArray.length] = this.route.snapshot.queryParams[ 'wort' ];

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -115,7 +115,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Notizbuch 1979',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'notizbuchForm'
     },
     {
       'konvolut': 'notizbuch-1979-1982',
@@ -124,7 +125,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Notizbuch 1979 - 82',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'notizbuchForm'
     },
     {
       'konvolut': 'notizbuch-1980-1988',
@@ -133,7 +135,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Notizbuch 1980 - 1988',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'notizbuchForm'
     },
     {
       'konvolut': 'manuskripte-1979',
@@ -142,7 +145,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Manuskripte 1979',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'manuskriptForm'
     },
     {
       'konvolut': 'manuskripte-1979-1983',
@@ -151,7 +155,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Manuskripte 1979 - 1983',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'manuskriptForm'
     },
     {
       'konvolut': 'karten-1984',
@@ -160,7 +165,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Karten 1984',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'manuskriptForm'
     },
     {
       'konvolut': 'typoskripte-1979',
@@ -169,7 +175,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Typoskripte 1979',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'typoskriptForm'
     },
     {
       'konvolut': 'typoskripte-1979-spez',
@@ -178,7 +185,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Typoskripte 1979 - spez',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'typoskriptForm'
     },
     {
       'konvolut': 'typoskripte-1983',
@@ -187,7 +195,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Manuskripte 1983',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'typoskriptForm'
     },
     {
       'konvolut': 'gesicht-im-mittag',
@@ -196,7 +205,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Gesicht im Mittag',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
     },
     {
       'konvolut': 'die-verwandelten-schiffe',
@@ -205,7 +215,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Die verwandelten Schiffe',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
     },
     {
       'konvolut': 'gedichte',
@@ -214,7 +225,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Gedichte',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
     },
     {
       'konvolut': 'flussufer',
@@ -223,7 +235,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Flussufer',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
     },
     {
       'konvolut': 'reduktionen',
@@ -232,7 +245,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Reduktionen',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
     },
     {
       'konvolut': 'abgewandt-zugewandt-hochdeutsche-gedichte',
@@ -241,7 +255,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Abgewandt Zugewandt 1985 – Hochdeutsche Gedichte',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
     },
     {
       'konvolut': 'abgewandt-zugewandt-alemannische-gedichte',
@@ -250,7 +265,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Abgewandt Zugewandt 1985 – Alemannische Gedichte',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'druckForm'
     },
     {
       'konvolut': 'akzente',
@@ -259,7 +275,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Akzente',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'blaetter+bilder',
@@ -268,7 +285,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Blätter + Bilder',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftSchoenste',
@@ -277,7 +295,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Schönste',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftTag',
@@ -286,7 +305,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Tag',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftTat',
@@ -295,7 +315,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Tat',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftZeit',
@@ -304,7 +325,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'DIE ZEIT',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftEnsemble',
@@ -313,7 +335,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'ensemble',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftHortulus',
@@ -322,7 +345,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Hortulus',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftJahresring',
@@ -331,7 +355,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Jahresring',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftKonturen',
@@ -340,7 +365,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Konturen',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftLNN',
@@ -349,7 +375,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Luzerner Neueste Nachrichten',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftLadZ',
@@ -358,7 +385,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Lyrik aus dieser Zeit',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftLuZ',
@@ -367,7 +395,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Lyrik unserer Zeit',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftMerkur',
@@ -376,7 +405,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Merkur',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftDeutscheHefte',
@@ -385,7 +415,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Neue Deutsche Hefte',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftNZN',
@@ -394,7 +425,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Neue Zürcher Nachrichten',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftNZZ',
@@ -403,7 +435,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Neue Zürcher Zeitung',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftRenaissance',
@@ -412,7 +445,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Renaissance',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftRundschau',
@@ -421,7 +455,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Schweizer Rundschau',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftSueddeutsche',
@@ -430,7 +465,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Sueddeutsche Zeitung',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'zeitschriftWortTat',
@@ -439,7 +475,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Wort und Tat',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     },
     {
       'konvolut': 'materialienTagebuch',
@@ -448,7 +485,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       'IRI': 'undefined',
       'memberPoems': new Set(),
       'officialName': 'Tagebuch',
-      'index': this.createConvoluteIndex()
+      'index': this.createConvoluteIndex(),
+      'suchmaskeFormName': 'zeitschriftForm'
     }
   ];
   poemResTypes = [
@@ -485,7 +523,6 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   handleSearchEvent(arg: AbstractControl) {
     //console.log(arg);
     if(this.startSearchImmediately) this.startSearchImmediately = false;
-    //console.log(arg);
     this.arg = arg;
     this.updateSuchmaskeKonvolutIRIMapping(arg);
     //Send String to Parser:
@@ -503,10 +540,8 @@ export class SucheComponent implements OnInit, AfterViewChecked {
     for (this.o = 0; this.o < this.suchmaskeKonvolutIRIMapping.length; this.o++) {
       this.getKonvolutIRI(this.suchmaskeKonvolutIRIMapping[ this.o ].konvolut, this.o);
     }
-    console.log(this.suchmaskeKonvolutIRIMapping);
     if (this.route.snapshot.queryParams[ 'wort' ]) {
       for ( let konvolut of this.suchmaskeKonvolutIRIMapping ) {
-        console.log(konvolut);
         konvolut.enabled = this.updateFilterParams(this.route.snapshot.queryParams[ konvolut.suchmaskeKonvolutName ], true);
       }
       this.startSearchImmediately = true;
@@ -826,19 +861,12 @@ export class SucheComponent implements OnInit, AfterViewChecked {
     } else {
       if (searchResults !== undefined) {
         this.addToFinalSearchResultArray(searchResults, undefined);
-/*      }
-      if (poemIRI !== undefined) {
-        this.addToFinalSearchResultArray(undefined, poemIRI);*/
       }
     }
   }
 
   addToFinalSearchResultArray(searchResults: Array<any>, singlePoem: any) {
     this.checkProgress();
-    //console.log('Add to final Search Results');
-    //console.log(searchResults);
-    //console.log(singlePoem);
-    //console.log(this.suchmaskeKonvolutIRIMapping);
     if (this.allSearchResults === undefined) {
       this.allSearchResults = [];
     }
@@ -858,7 +886,6 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   }
 
   updateSuchmaskeKonvolutIRIMapping(arg: AbstractControl) {
-    //console.log(arg);
     if (
       arg.get('notizbuchForm').pristine
       && arg.get('druckForm').pristine
@@ -870,46 +897,9 @@ export class SucheComponent implements OnInit, AfterViewChecked {
       //console.log('Perform Search in all convolutes');
       console.log(this.suchmaskeKonvolutIRIMapping);
     } else {
-      //console.log('Gehe durch jedes Konvolut');
-      this.suchmaskeKonvolutIRIMapping[ 0 ].enabled = arg.get('notizbuchForm.notizbuch79').value;
-      this.suchmaskeKonvolutIRIMapping[ 1 ].enabled = arg.get('notizbuchForm.notizbuch7982').value;
-      this.suchmaskeKonvolutIRIMapping[ 2 ].enabled = arg.get('notizbuchForm.notizbuch8088').value;
-      this.suchmaskeKonvolutIRIMapping[ 3 ].enabled = arg.get('manuskriptForm.manuskript79').value;
-      this.suchmaskeKonvolutIRIMapping[ 4 ].enabled = arg.get('manuskriptForm.manuskript7983').value;
-      this.suchmaskeKonvolutIRIMapping[ 5 ].enabled = arg.get('manuskriptForm.manuskriptKarten').value;
-      this.suchmaskeKonvolutIRIMapping[ 6 ].enabled = arg.get('typoskriptForm.typoskript79').value;
-      this.suchmaskeKonvolutIRIMapping[ 7 ].enabled = arg.get('typoskriptForm.typoskript79Spez').value;
-      this.suchmaskeKonvolutIRIMapping[ 8 ].enabled = arg.get('typoskriptForm.typoskript83').value;
-      this.suchmaskeKonvolutIRIMapping[ 9 ].enabled = arg.get('druckForm.druckGesicht').value;
-      this.suchmaskeKonvolutIRIMapping[ 10 ].enabled = arg.get('druckForm.druckSchiffe').value;
-      this.suchmaskeKonvolutIRIMapping[ 11 ].enabled = arg.get('druckForm.druckGedichte').value;
-      this.suchmaskeKonvolutIRIMapping[ 12 ].enabled = arg.get('druckForm.druckFlussufer').value;
-      this.suchmaskeKonvolutIRIMapping[ 13 ].enabled = arg.get('druckForm.druckReduktionen').value;
-      this.suchmaskeKonvolutIRIMapping[ 14 ].enabled = arg.get('zeitschriftForm.zeitschriftAkzente').value;
-      this.suchmaskeKonvolutIRIMapping[ 15 ].enabled = arg.get('zeitschriftForm.zeitschriftBlaetter').value;
-      this.suchmaskeKonvolutIRIMapping[ 16 ].enabled = arg.get('zeitschriftForm.zeitschriftSchoenste').value;
-      this.suchmaskeKonvolutIRIMapping[ 17 ].enabled = arg.get('zeitschriftForm.zeitschriftTag').value;
-      this.suchmaskeKonvolutIRIMapping[ 18 ].enabled = arg.get('zeitschriftForm.zeitschriftTat').value;
-      this.suchmaskeKonvolutIRIMapping[ 19 ].enabled = arg.get('zeitschriftForm.zeitschriftZeit').value;
-      this.suchmaskeKonvolutIRIMapping[ 20 ].enabled = arg.get('zeitschriftForm.zeitschriftEnsemble').value;
-      this.suchmaskeKonvolutIRIMapping[ 21 ].enabled = arg.get('zeitschriftForm.zeitschriftHortulus').value;
-      this.suchmaskeKonvolutIRIMapping[ 22 ].enabled = arg.get('zeitschriftForm.zeitschriftJahresring').value;
-      this.suchmaskeKonvolutIRIMapping[ 23 ].enabled = arg.get('zeitschriftForm.zeitschriftKonturen').value;
-      this.suchmaskeKonvolutIRIMapping[ 24 ].enabled = arg.get('zeitschriftForm.zeitschriftLNN').value;
-      this.suchmaskeKonvolutIRIMapping[ 25 ].enabled = arg.get('zeitschriftForm.zeitschriftLadZ').value;
-      this.suchmaskeKonvolutIRIMapping[ 26 ].enabled = arg.get('zeitschriftForm.zeitschriftLuZ').value;
-      this.suchmaskeKonvolutIRIMapping[ 27 ].enabled = arg.get('zeitschriftForm.zeitschriftMerkur').value;
-      this.suchmaskeKonvolutIRIMapping[ 28 ].enabled = arg.get('zeitschriftForm.zeitschriftDeutscheHefte').value;
-      this.suchmaskeKonvolutIRIMapping[ 29 ].enabled = arg.get('zeitschriftForm.zeitschriftNZN').value;
-      this.suchmaskeKonvolutIRIMapping[ 30 ].enabled = arg.get('zeitschriftForm.zeitschriftNZZ').value;
-      this.suchmaskeKonvolutIRIMapping[ 31 ].enabled = arg.get('zeitschriftForm.zeitschriftRenaissance').value;
-      this.suchmaskeKonvolutIRIMapping[ 32 ].enabled = arg.get('zeitschriftForm.zeitschriftRundschau').value;
-      this.suchmaskeKonvolutIRIMapping[ 33 ].enabled = arg.get('zeitschriftForm.zeitschriftSueddeutsche').value;
-      this.suchmaskeKonvolutIRIMapping[ 34 ].enabled = arg.get('zeitschriftForm.zeitschriftWortTat').value;
-      this.suchmaskeKonvolutIRIMapping[ 35 ].enabled = arg.get('materialienForm.materialienTagebuch').value;
-      this.suchmaskeKonvolutIRIMapping[ 36 ].enabled = arg.get('druckForm.druckAbgewandtAll').value;
-      console.log(this.suchmaskeKonvolutIRIMapping[ 35 ].enabled);
-      //console.log(this.suchmaskeKonvolutIRIMapping);
+      for ( let konvolut of this.suchmaskeKonvolutIRIMapping ) {
+        konvolut.enabled = arg.get( konvolut.suchmaskeFormName + '.' + konvolut.suchmaskeKonvolutName ).value;
+      }
     }
   }
   updateQueryParamsInURL() {


### PR DESCRIPTION
Filtern nach Konvoluten sollte wieder funktionieren.

Beispiel test an suche nach "zuunterst", anschliessend einmal Notizbücher rausnehmen, dann sollte nur eines der Typoskripte erscheinen, und anders herum sollte es natürlich auch gehen. Gern auch weitere Filter ausprobieren