### PR TITLE
Nie 285 bis 288 small bugs

### DIFF
--- a/src/client/app/shared/textgrid/textgrid.component.html
+++ b/src/client/app/shared/textgrid/textgrid.component.html
@@ -38,7 +38,9 @@
           *ngIf="p"
           [ngClass]="{'rae-poem-card-content-grid': viewMode == 'grid', 'rae-poem-card-content-cols': viewMode == 'cols', 'hidden': !showText}"
           [ngStyle]="{'height': rahmen ? 'calc(10em - '+poemTitle.offsetHeight+'px + '+gridTextHeight+'em)' :  'calc(15px + '+poemText.offsetHeight+'px)', 'overflow-y': rahmen ? 'auto' : 'auto'}">
-          <div class="rae-poem" [innerHTML]="highlight(p.poemText,searchTermArray)" #poemText>
+          <div class="rae-poem"
+               [innerHTML]="highlight(p.poemText,searchTermArray)"
+               #poemText>
           </div>
         </md-card-content>
 

--- a/src/client/app/suche/basic-search/basic-search.component.html
+++ b/src/client/app/suche/basic-search/basic-search.component.html
@@ -1,7 +1,14 @@
-<input  #searchfield [placeholder]="placeholder" (focus)="placeholder=''"
-        (keyup.enter)="sendRequest(searchfield.value)" style="width: 120px;">
-<button md-icon-button class="search-button"
-        (click)="sendRequest(searchfield.value)" style="padding-top: 7px;">
+<input  #searchfield
+        [placeholder]="placeholder"
+        (focus)="placeholder=''"
+        (keyup.enter)="sendRequest(searchfield.value)"
+        style="width: 120px;"
+        (keyup.enter)="searchfield.value = ''">
+<button md-icon-button
+        class="search-button"
+        (click)="sendRequest(searchfield.value)"
+        (click)="searchfield.value = ''"
+        style="padding-top: 7px;">
   <md-icon>search</md-icon>
 </button>
 

--- a/src/client/app/suche/suche.component.html
+++ b/src/client/app/suche/suche.component.html
@@ -29,7 +29,6 @@
                 <rae-suchmaske [lastSearchTerm] = "sendInputStringToSuchmaske"
                                [loadingIndicatorInput] = "loadingIndicatorInput"
                                [startSearchImmediately]="startSearchImmediately"
-                               [sidenavOpened]="true"
                                (suchEvents)="handleSearchEvent($event)"
                                [poemsInGrid]="allSearchResults"
                                (startSearch)="executeFinalQueries()"

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -96,7 +96,7 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   }
 
   handleSearchEvent(arg: AbstractControl) {
-    if(this.startSearchImmediately) this.startSearchImmediately = false;
+    this.startSearchImmediately = false;
     this.arg = arg;
     this.updateSuchmaskeKonvolutIRIMapping(arg);
     //Send String to Parser:
@@ -117,6 +117,7 @@ export class SucheComponent implements OnInit, AfterViewChecked {
     //   this.getKonvolutIRI(konvolut.konvolut, konvolut.index);
     // }
     if (this.route.snapshot.queryParams[ 'wort' ]) {
+      this.startSearchImmediately = true;
       for ( let i = 0; i < this.suchmaskeKonvolutIRIMapping.length; i ++ ) {
         this.suchmaskeKonvolutIRIMapping[ i ].enabled =
           this.updateFilterParams(
@@ -124,13 +125,9 @@ export class SucheComponent implements OnInit, AfterViewChecked {
             true
           );
       }
-      this.startSearchImmediately = true;
       this.searchTermArray = [ ];
       this.searchTermArray[ this.searchTermArray.length ] = this.route.snapshot.queryParams[ 'wort' ];
-      //setTimeout(() => {
-        //console.log('Wait for Konvolutes to load');
         this.inputSearchStringToBeParsed = this.route.snapshot.queryParams[ 'wort' ];
-      //}, 3000);
 
     }
     if ( this.allSearchResults === undefined ) {
@@ -141,6 +138,7 @@ export class SucheComponent implements OnInit, AfterViewChecked {
   }
 
   executeFinalQueries() {
+    this.startSearchImmediately = false;
     this.checkProgress();
     this.menuArray = [];
     this.noMoreChange = false;

--- a/src/client/app/suche/suche.component.ts
+++ b/src/client/app/suche/suche.component.ts
@@ -377,19 +377,21 @@ export class SucheComponent implements OnInit, AfterViewChecked {
                       if( this.checkIfHasStrophe( poem.value[ '9' ] ) ) {
                         if( this.checkIfIsInDialect(poem.value[ '14' ] ) ) {
                           if( this.checkIfPartOfCycle( poem.value[ '15' ] ) ) {
-                            poem.reservedPointer = this.helpArray.length;
-                            this.helpArray[ poem.reservedPointer ] = new CachePoem();
-                            this.helpArray[ poem.reservedPointer ].poemTitle = poem.value['8'];
-                            this.helpArray[ poem.reservedPointer ].poemCreationDate = poem.value['5'];
-                            this.helpArray[ poem.reservedPointer ].poemText = poem.value['7'];
-                            this.helpArray[ poem.reservedPointer ].poemIRI = poem.value['6'];
-                            this.helpArray[ poem.reservedPointer ].synopsisIRI = poem.value['11'];
-                            this.helpArray[ poem.reservedPointer ].synopsisTitle = poem.value['12'];
-                            this.helpArray[ poem.reservedPointer ].isFinalVersion = poem.value['13'];
-                            this.helpArray[ poem.reservedPointer ].searchOfficialName = poem.value['3'];
-                            this.numberOfSearchResults += 1;
-                            this.sortResultArray();
-                            this.renderPage();
+                            if( this.checkIfSearchTermIsInHtml( poem.value['7'] ) ) {
+                              poem.reservedPointer = this.helpArray.length;
+                              this.helpArray[ poem.reservedPointer ] = new CachePoem();
+                              this.helpArray[ poem.reservedPointer ].poemTitle = poem.value['8'];
+                              this.helpArray[ poem.reservedPointer ].poemCreationDate = poem.value['5'];
+                              this.helpArray[ poem.reservedPointer ].poemText = poem.value['7'];
+                              this.helpArray[ poem.reservedPointer ].poemIRI = poem.value['6'];
+                              this.helpArray[ poem.reservedPointer ].synopsisIRI = poem.value['11'];
+                              this.helpArray[ poem.reservedPointer ].synopsisTitle = poem.value['12'];
+                              this.helpArray[ poem.reservedPointer ].isFinalVersion = poem.value['13'];
+                              this.helpArray[ poem.reservedPointer ].searchOfficialName = poem.value['3'];
+                              this.numberOfSearchResults += 1;
+                              this.sortResultArray();
+                              this.renderPage();
+                            }
                           }
                         }
                       }
@@ -399,6 +401,15 @@ export class SucheComponent implements OnInit, AfterViewChecked {
               }
           }
     }
+
+  checkIfSearchTermIsInHtml( poemText: string ) {
+    for( let searchTerm of this.searchTermArray ) {
+      if(poemText
+          .replace(/<(?:.|\n)*?>/gm, '')
+          .search(searchTerm) !== -1
+      ) return true;
+    } return false;
+  }
 
   checkIfKonvolutIsChosen(poem: any) {
     if( this.setOfAllowedConvolutes.has(poem.value['3'] ) ) return true;

--- a/src/client/app/suche/suchmaske/suchmaske.component.html
+++ b/src/client/app/suche/suchmaske/suchmaske.component.html
@@ -840,14 +840,13 @@
         <ngb-panel title="Zeitraum">
           <ng-template ngbPanelContent>
             <div formGroupName="zeitraumForm">
-              von
-              <md-input-container style="width: 70px; align: center">
-                <input mdInput formControlName="zeitraumVon" class="ip-epoche"  />
-              </md-input-container>
-              bis
-              <md-input-container style="width: 70px; align: center">
-                <input mdInput formControlName="zeitraumBis" class="ip-epoche"/>
-              </md-input-container>
+              <md-select formControlName="zeitraumVon" placeholder="Von" [(ngModel)]="chosenStartYear">
+                <md-option [value]="year" *ngFor="let year of yearPickerArray; let i = index">{{ year }}</md-option>
+              </md-select>
+              <md-select formControlName="zeitraumBis" placeholder="Bis" [(ngModel)]="chosenEndYear">
+                <md-option [value]="year" *ngFor="let year of yearPickerArray; let i = index">{{ year }}</md-option>
+              </md-select>
+              <span *ngIf="chosenStartYear > chosenEndYear"style="color: darkred;"> <br>Das Enddatum liegt vor dem Startdatum!</span>
             </div>
           </ng-template>
         </ngb-panel>

--- a/src/client/app/suche/suchmaske/suchmaske.component.ts
+++ b/src/client/app/suche/suchmaske/suchmaske.component.ts
@@ -39,6 +39,12 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   textsHaveAlignedFrames: boolean = false;
   showTexts: boolean = true;
   navIsFixed = false;
+  yearPickerArray: Array<any>;
+  endYearPickerArray: Array<any>;
+  firstYear = 1948;
+  lastYear = 1992;
+  chosenStartYear: number;
+  chosenEndYear: number;
 
   /*
    Options for extension of fulltext search
@@ -117,6 +123,10 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   }
 
   ngOnInit() {
+    this.yearPickerArray = [];
+    for(let i = 0; i < this.lastYear - this.firstYear; i++) {
+      this.yearPickerArray[ i ] = this.firstYear + i;
+    }
     //this.onSearchParamsChange();
   }
 
@@ -267,4 +277,5 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   openAndCloseSidenav() {
     this.sidenavOpened = !this.sidenavOpened;
   }
+
 }

--- a/src/client/app/suche/suchmaske/suchmaske.component.ts
+++ b/src/client/app/suche/suchmaske/suchmaske.component.ts
@@ -27,7 +27,6 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   @Output() startSearch: EventEmitter<any> = new EventEmitter<any>();
   // Form model which contains all search parameters
   suchmenuForm: FormGroup;
-  @Input() sidenavOpened: boolean;
   @Input() searchTermArray: Array<string>;
   @Input() poemsInGrid: string;
   @Input() startSearchImmediately: boolean;
@@ -45,6 +44,7 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   lastYear = 1992;
   chosenStartYear: number;
   chosenEndYear: number;
+  sidenavOpened = true;
 
   /*
    Options for extension of fulltext search
@@ -114,7 +114,6 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   ngOnChanges() {
     //console.log(this.loadingIndicator);
     this.loadingIndicator = this.loadingIndicatorInput;
-    if (this.startSearchImmediately) this.sidenavOpened = false;
     //console.log('Data arrived back in Suchmaske: ');
     //console.log(this.poemsInGrid);
     //console.log(this.searchTermArray);
@@ -123,6 +122,7 @@ export class SuchmaskeComponent implements OnChanges, OnInit {
   }
 
   ngOnInit() {
+    if( this.startSearchImmediately ) this.sidenavOpened = false;
     this.yearPickerArray = [];
     for(let i = 0; i < this.lastYear - this.firstYear; i++) {
       this.yearPickerArray[ i ] = this.firstYear + i;


### PR DESCRIPTION
Lieber Reinhard,
zu testen wäre, worüber wir schon gesprochen haben:

NIE-288: Die Suchleiste links klappt nicht einfach so "manchmal zufällig" zu, nur wenn man die Suche von der einfachen Suche startet klappt es zu bzw ist nicht offen, wenn man von einer anderen Komponente kommt.

NIE-287: Das Suchwort in der einfachen Suche verschwindet, wenn man die Suche auslöst, steht aber weiterhin links in der Suchleiste (hierdurch wird ein Klick gespart)

NIE-286: Suche nach "style" oder = oder anderen html - Elementen führt nicht dazu, dass komische Ergebnisse inklusive html angezeigt werden. (Dieser Effekt wurde durch die Funktion highlightText ausgelöst, ein Teil der html-tags wurde durch <span>...</span> ersetzt, sodass es für innerhtml nicht mehr als html erkannt wurde. Dies sollte jetzt behoben sein. Es wird zwar durch Knora weiterhin auch im html gesucht, da es zum String des Poems gehört, jedoch wird es nicht an die Suchergebnisse weitergeleitet, wenn der Searchterm nur im html vorkommt. 

NIE-285: Jahresauswahl: Man wählt das Jahr jetzt aus einem Dropdown aus. @sschuepbach , @sacha-alex @hanscools , wisst ihr, welches Jahr des Poems das jüngste ist? Ich habe erst einmal 1992 genommen, bin mir aber nicht sicher. Und das Jüngste ist 1948, wenn ich mich nicht irre, bitte auch hier um Bestätigung.

Vielen Dank und viele schöne Grüsse,
Jan