### PR TITLE
NIE-395 Infobox "Testversion" / Link zu kunoraeber.ch

### DIFF
--- a/src/client/app/core/core-routing.module.ts
+++ b/src/client/app/core/core-routing.module.ts
@@ -1,7 +1,5 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-
-import { HomepageComponent } from '../statisch/homepage.component';
 import { ImpressumComponent } from '../statisch/impressum.component';
 import { SignaturenComponent } from '../statisch/signaturen.component';
 import { WerklisteSelbstComponent } from '../statisch/werkliste-selbst.component';
@@ -14,44 +12,27 @@ import { SucheModule } from '../suche/suche.module';
 import { PdfNotizbuecherComponent } from '../statisch/pdf-notizbuecher.component';
 import { PdfSynopsenComponent } from '../statisch/pdf-synopsen.component';
 import { PageNotFoundComponent } from './404.component';
-import { HomepageWithInitTextComponent } from '../statisch/homepagewithinittext.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @NgModule({
   imports: [
     SucheModule,
     RouterModule.forRoot([
-      { path: 'werkausgabe', component: WerkausgabeComponent },
-      { path: 'textausgaben', component: TextausagabenComponent },
-      { path: 'material/pdf-dateien/notizbuecher', component: PdfNotizbuecherComponent },
-      { path: 'anleitung', component: AnleitungComponent },
-      { path: 'lebensdaten', component: LebensdatenComponent },
-      { path: 'werkliste-selbst', component: WerklisteSelbstComponent },
-      { path: 'werkliste-unselbst', component: WerklisteUnselbstComponent },
-      { path: 'signaturen', component: SignaturenComponent },
-      { path: 'impressum', component: ImpressumComponent },
-      { path: 'material/pdf-dateien/synopsen', component: PdfSynopsenComponent },
-      { path: '', redirectTo: '/init', pathMatch: 'full' },
-      { path: '**', component: PageNotFoundComponent }
+      {path: 'werkausgabe', component: WerkausgabeComponent, canActivate: [TestversionGuard]},
+      {path: 'textausgaben', component: TextausagabenComponent, canActivate: [TestversionGuard]},
+      {path: 'material/pdf-dateien/notizbuecher', component: PdfNotizbuecherComponent, canActivate: [TestversionGuard]},
+      {path: 'anleitung', component: AnleitungComponent, canActivate: [TestversionGuard]},
+      {path: 'lebensdaten', component: LebensdatenComponent, canActivate: [TestversionGuard]},
+      {path: 'werkliste-selbst', component: WerklisteSelbstComponent, canActivate: [TestversionGuard]},
+      {path: 'werkliste-unselbst', component: WerklisteUnselbstComponent, canActivate: [TestversionGuard]},
+      {path: 'signaturen', component: SignaturenComponent, canActivate: [TestversionGuard]},
+      {path: 'impressum', component: ImpressumComponent, canActivate: [TestversionGuard]},
+      {path: 'material/pdf-dateien/synopsen', component: PdfSynopsenComponent, canActivate: [TestversionGuard]},
+      {path: '', redirectTo: '/start', pathMatch: 'full'},
+      {path: '**', component: PageNotFoundComponent, canActivate: [TestversionGuard]}
     ])
   ],
   exports: [ RouterModule ]
 })
 export class CoreRoutingModule {
 }
-
-export const routingComponents = [
-  AnleitungComponent,
-  HomepageComponent,
-  HomepageWithInitTextComponent,
-  ImpressumComponent,
-  LebensdatenComponent,
-  PageNotFoundComponent,
-  PdfNotizbuecherComponent,
-  PdfSynopsenComponent,
-  SignaturenComponent,
-  WerkausgabeComponent,
-  TextausagabenComponent,
-  WerklisteSelbstComponent,
-  WerklisteUnselbstComponent
-];
-

--- a/src/client/app/core/core.module.ts
+++ b/src/client/app/core/core.module.ts
@@ -32,8 +32,9 @@ import {
   MdSlideToggleModule,
   MdToolbarModule
 } from '@angular/material';
-import { CoreRoutingModule } from './core-routing.module';
+import { CoreRoutingModule, routingComponents } from './core-routing.module';
 import { ScrollToTopComponent } from './scroll-to-top.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @NgModule({
   imports: [
@@ -60,17 +61,16 @@ import { ScrollToTopComponent } from './scroll-to-top.component';
     MdInputModule,
     NgbModule.forRoot(),
     CoreRoutingModule
-    /*    RouterModule.forRoot([
-      { path: '', redirectTo: '/start', pathMatch: 'full' },
-      { path: '**', component: PageNotFoundComponent }
-     ])*/
   ],
   declarations: [
     KopfzeileComponent,
     HaupttextComponent,
     NavigationsleisteComponent,
     PageNotFoundComponent,
-    ScrollToTopComponent
+    ScrollToTopComponent,
+  ],
+  providers: [
+    TestversionGuard
   ],
   exports: [
     KopfzeileComponent,

--- a/src/client/app/core/core.module.ts
+++ b/src/client/app/core/core.module.ts
@@ -32,7 +32,7 @@ import {
   MdSlideToggleModule,
   MdToolbarModule
 } from '@angular/material';
-import { CoreRoutingModule, routingComponents } from './core-routing.module';
+import { CoreRoutingModule } from './core-routing.module';
 import { ScrollToTopComponent } from './scroll-to-top.component';
 import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 

--- a/src/client/app/fassung/fassung-routing.module.ts
+++ b/src/client/app/fassung/fassung-routing.module.ts
@@ -5,11 +5,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { FassungComponent } from './fassung.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @NgModule({
   imports: [
     RouterModule.forChild([
-      { path: ':konvolut/:fassung', component: FassungComponent }
+      {path: ':konvolut/:fassung', component: FassungComponent, canActivate: [TestversionGuard]}
     ])
   ],
   exports: [ RouterModule ]

--- a/src/client/app/konvolut/konvolut-routing.module.ts
+++ b/src/client/app/konvolut/konvolut-routing.module.ts
@@ -6,285 +6,342 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { KonvolutComponent } from './konvolut.component';
 import { ConvoluteNotAvailableComponent } from './convolute-not-available.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @NgModule({
   imports: [
     RouterModule.forChild([
       {
         path: 'drucke/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1948-1951',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1948-51' }
+        data: {title: 'Manuskripte 1948-51'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1951',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1951' }
+        data: {title: 'Manuskripte 1951'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1952',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1952' }
+        data: {title: 'Manuskripte 1952'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1953',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1953' }
+        data: {title: 'Manuskripte 1953'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1954',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1954' }
+        data: {title: 'Manuskripte 1954'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1955',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1955' }
+        data: {title: 'Manuskripte 1955'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1956',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1956' }
+        data: {title: 'Manuskripte 1956'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1957',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1957' }
+        data: {title: 'Manuskripte 1957'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1958',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1958' }
+        data: {title: 'Manuskripte 1958'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1958-1959',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1958-59' }
+        data: {title: 'Manuskripte 1958-59'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1959-1960',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1959-60' }
+        data: {title: 'Manuskripte 1959-60'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1961',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1961' }
+        data: {title: 'Manuskripte 1961'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1962',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1962' }
+        data: {title: 'Manuskripte 1962'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1963',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1963' }
+        data: {title: 'Manuskripte 1963'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/manuskripte-1964-1965',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Manuskripte 1964-65' }
+        data: {title: 'Manuskripte 1964-65'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'manuskripte/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-divers/notizbuch-1965-80',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1965-80' }
+        data: {title: 'Notizbuch 1965-80'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-divers/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1948-1949',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1948-49' }
+        data: {title: 'Notizbuch 1948-49'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1949',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1949' }
+        data: {title: 'Notizbuch 1949'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1950',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1950' }
+        data: {title: 'Notizbuch 1950'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1950-1951',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1950-51' }
+        data: {title: 'Notizbuch 1950-51'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1952-1954',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1952-54' }
+        data: {title: 'Notizbuch 1952-54'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1954-1955',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1954-55' }
+        data: {title: 'Notizbuch 1954-55'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1955-1957',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1955-57' }
+        data: {title: 'Notizbuch 1955-57'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1957-1958',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1957-58' }
+        data: {title: 'Notizbuch 1957-58'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1958-1961',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1958-61' }
+        data: {title: 'Notizbuch 1958-61'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/notizbuch-1961-1965',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Notizbuch 1961-65' }
+        data: {title: 'Notizbuch 1961-65'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'notizbuecher/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-sammlungen/sammlung-kutter',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Sammlung Kutter' }
+        data: {title: 'Sammlung Kutter'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-sammlungen/sammlung-thomas-raeber',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Sammlung Th. Raeber' }
+        data: {title: 'Sammlung Th. Raeber'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-sammlungen/sammlung-hochstrasser',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Sammlung Hochstrasser' }
+        data: {title: 'Sammlung Hochstrasser'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-sammlungen/typoskripte-divers',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte divers' }
+        data: {title: 'Typoskripte divers'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-sammlungen/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1943-1946',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1943-46' }
+        data: {title: 'Typoskripte 1943-46'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1945-1950',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1945-50' }
+        data: {title: 'Typoskripte 1945-50'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1948-1950',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1948-50' }
+        data: {title: 'Typoskripte 1948-50'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1951',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1951' }
+        data: {title: 'Typoskripte 1951'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1952',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1952' }
+        data: {title: 'Typoskripte 1952'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1953',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1953' }
+        data: {title: 'Typoskripte 1953'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1954',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1954' }
+        data: {title: 'Typoskripte 1954'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1955',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1955' }
+        data: {title: 'Typoskripte 1955'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1956',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1956' }
+        data: {title: 'Typoskripte 1956'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1957',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1957' }
+        data: {title: 'Typoskripte 1957'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte1958',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1958' }
+        data: {title: 'Typoskripte 1958'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte1959',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1959' }
+        data: {title: 'Typoskripte 1959'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1960',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1960' }
+        data: {title: 'Typoskripte 1960'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1961',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1961' }
+        data: {title: 'Typoskripte 1961'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1962',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1962' }
+        data: {title: 'Typoskripte 1962'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1963',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1963' }
+        data: {title: 'Typoskripte 1963'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/typoskripte-1965',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Typoskripte 1965' }
+        data: {title: 'Typoskripte 1965'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'typoskripte/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       },
       {
         path: 'material/tagebuecher-2',
         component: ConvoluteNotAvailableComponent,
-        data: { title: 'Briefe' }
+        data: {title: 'Briefe'},
+        canActivate: [TestversionGuard]
       },
       {
         path: 'material/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       },
       {
         path: 'suchergebnisse/:konvolut',
-        component: KonvolutComponent
+        component: KonvolutComponent,
+        canActivate: [TestversionGuard]
       }
     ])
   ],
-  exports: [ RouterModule ]
+  exports: [RouterModule]
 })
 export class KonvolutRoutingModule {
 }

--- a/src/client/app/register/register.module.ts
+++ b/src/client/app/register/register.module.ts
@@ -13,6 +13,7 @@ import { RouterModule } from '@angular/router';
 import { FromKonvolutIRIToPoemIRIsModule } from '../shared/fromKonvolutIRIToPoemIRIs/fromKonvolutIRIToPoemIRIs.module';
 import { FromPoemIRIToTextgridInformationModule } from '../shared/fromPoemIRIToTextgridInformation/FromPoemIRIToTextgridInformation.module';
 import { GetKonvolutIRIsComponent } from './titelregister/get-konvolut-IRIs.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 
 @NgModule({
@@ -24,8 +25,8 @@ import { GetKonvolutIRIsComponent } from './titelregister/get-konvolut-IRIs.comp
     MdButtonModule,
     MdListModule,
     RouterModule.forChild([
-      { path: 'register', component: RegisterComponent },
-      { path: 'register/:zeitraum', component: RegisterComponent }
+      {path: 'register', component: RegisterComponent, canActivate: [TestversionGuard]},
+      {path: 'register/:zeitraum', component: RegisterComponent, canActivate: [TestversionGuard]}
     ])
   ],
   declarations: [

--- a/src/client/app/shared/testversion-service/testversion-guard.service.ts
+++ b/src/client/app/shared/testversion-service/testversion-guard.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+
+@Injectable()
+export class TestversionGuard implements CanActivate {
+
+  redirectUrl: string;
+  private _testversionInfoAccepted = false;
+
+  constructor(private router: Router) {
+  }
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    return this._checkTestversionInfoAccepted(state.url);
+  }
+
+  acceptTestversionInfo() {
+    this._testversionInfoAccepted = true;
+  }
+
+  private _checkTestversionInfoAccepted(url: string): boolean {
+    if (this._testversionInfoAccepted) {
+      return true;
+    }
+
+    this.redirectUrl = url;
+    this.router.navigate(['/init']);
+    return false;
+  }
+
+}

--- a/src/client/app/statisch/homepagewithinittext.component.ts
+++ b/src/client/app/statisch/homepagewithinittext.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MdDialog } from '@angular/material';
 import { InitKommentarComponent } from './initkommentar.component';
 import { Router } from '@angular/router';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @Component({
   moduleId: module.id,
@@ -11,7 +12,7 @@ import { Router } from '@angular/router';
 export class HomepageWithInitTextComponent {
 
 
-  constructor(public dialog: MdDialog, private router: Router) {
+  constructor(public dialog: MdDialog, private router: Router, private testversionGuard: TestversionGuard) {
     this.openDialog();
   }
 
@@ -22,8 +23,9 @@ export class HomepageWithInitTextComponent {
       height: '600px',
       disableClose: true
     });
-    dialogRef.afterClosed().subscribe(result => {
-      this.router.navigateByUrl('/start');
+    dialogRef.afterClosed().subscribe(() => {
+      this.testversionGuard.acceptTestversionInfo();
+      this.router.navigateByUrl(this.testversionGuard.redirectUrl);
     });
   }
 }

--- a/src/client/app/statisch/statisch-routing.module.ts
+++ b/src/client/app/statisch/statisch-routing.module.ts
@@ -13,21 +13,22 @@ import { TextausagabenComponent } from './textausgaben.component';
 import { PdfNotizbuecherComponent } from './pdf-notizbuecher.component';
 import { PdfSynopsenComponent } from './pdf-synopsen.component';
 import { HomepageWithInitTextComponent } from './homepagewithinittext.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @NgModule({
   imports: [
     RouterModule.forChild([
-      { path: 'werkausgabe', component: WerkausgabeComponent },
-      { path: 'textausgaben', component: TextausagabenComponent},
-      { path: 'material/pdf-dateien/notizbuecher', component: PdfNotizbuecherComponent },
-      { path: 'anleitung', component: AnleitungComponent },
-      { path: 'lebensdaten', component: LebensdatenComponent },
-      { path: 'werkliste-selbst', component: WerklisteSelbstComponent },
-      { path: 'werkliste-unselbst', component: WerklisteUnselbstComponent},
-      { path: 'signaturen', component: SignaturenComponent },
-      { path: 'impressum', component: ImpressumComponent },
-      { path: 'material/pdf-dateien/synopsen', component: PdfSynopsenComponent },
-      { path: 'start', component: HomepageComponent },
+      {path: 'werkausgabe', component: WerkausgabeComponent, canActivate: [TestversionGuard]},
+      {path: 'textausgaben', component: TextausagabenComponent, canActivate: [TestversionGuard]},
+      {path: 'material/pdf-dateien/notizbuecher', component: PdfNotizbuecherComponent, canActivate: [TestversionGuard]},
+      {path: 'anleitung', component: AnleitungComponent, canActivate: [TestversionGuard]},
+      {path: 'lebensdaten', component: LebensdatenComponent, canActivate: [TestversionGuard]},
+      {path: 'werkliste-selbst', component: WerklisteSelbstComponent, canActivate: [TestversionGuard]},
+      {path: 'werkliste-unselbst', component: WerklisteUnselbstComponent, canActivate: [TestversionGuard]},
+      {path: 'signaturen', component: SignaturenComponent, canActivate: [TestversionGuard]},
+      {path: 'impressum', component: ImpressumComponent, canActivate: [TestversionGuard]},
+      {path: 'material/pdf-dateien/synopsen', component: PdfSynopsenComponent, canActivate: [TestversionGuard]},
+      {path: 'start', component: HomepageComponent, canActivate: [TestversionGuard]},
       { path: 'init', component: HomepageWithInitTextComponent }
     ])
   ],

--- a/src/client/app/suche/suche-routing.module.ts
+++ b/src/client/app/suche/suche-routing.module.ts
@@ -1,13 +1,14 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { SucheComponent } from './suche.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @NgModule({
   imports: [
     RouterModule.forChild([
-      { path: 'suche', component: SucheComponent },
-      { path: 'suche/:queryParameters', component: SucheComponent },
-      { path: 'resetSuche', component: SucheComponent }
+      {path: 'suche', component: SucheComponent, canActivate: [TestversionGuard]},
+      {path: 'suche/:queryParameters', component: SucheComponent, canActivate: [TestversionGuard]},
+      {path: 'resetSuche', component: SucheComponent, canActivate: [TestversionGuard]}
     ])
   ],
   exports: [ RouterModule ]

--- a/src/client/app/synopse/synopse.module.ts
+++ b/src/client/app/synopse/synopse.module.ts
@@ -21,6 +21,7 @@ import {
 import { SynopseComponent } from './synopse.component';
 import { SynopseWerkzeugleisteComponent } from './synopse-werkzeugleiste/synopse-werkzeugleiste.component';
 import { SynopseHilfeComponent } from './synopse-hilfe/synopse-hilfe.component';
+import { TestversionGuard } from '../shared/testversion-service/testversion-guard.service';
 
 @NgModule({
   imports: [
@@ -36,7 +37,7 @@ import { SynopseHilfeComponent } from './synopse-hilfe/synopse-hilfe.component';
     KonvolutModule,
     TextgridModule,
     RouterModule.forChild([
-      { path: 'synopsen/:synopse', component: SynopseComponent }
+      {path: 'synopsen/:synopse', component: SynopseComponent, canActivate: [TestversionGuard]}
     ])
   ],
   declarations: [


### PR DESCRIPTION
Die Infobox "Testversion" mit Link zu kunoraeber.ch erscheint immer beim Einstieg in die Seite unabhängig davon, ob über die Homepage oder über eine andere Route auf die Website zugegriffen wird. Wird die Information bestätigt, leitet die Applikation automatisch auf die gewünschte Seite weiter. Nach einer erstmaligen Bestätigung sollte die Infobox während der ganzen Session nicht mehr erscheinen.

Zu überprüfen mit dem Ausprobieren verschiedener Routes zur Website, bspw.:
- http://localhost:5555 (Startseite)
- http://localhost:5555/drucke/gesicht-im-mittag
- http://localhost:5555/GESICHT%20IM%20MITTAG%201950/Sonst%20d%C3%A4mmert%20immer%20augenlos%20die%20Stadt%20%E2%80%A6*---U9ggHkQpQlOr3zN2UGBQmg
- http://localhost:5555/resetSuche?wort=qu%C3%A4ck